### PR TITLE
Revamp Constructors

### DIFF
--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -1,0 +1,38 @@
+#![feature(test)]
+
+extern crate test;
+extern crate ratelimit_meter;
+
+use ratelimit_meter::{GCRA, Decider};
+use std::time::{Instant, Duration};
+use std::thread;
+
+
+#[bench]
+fn bench_20threads(b: &mut test::Bencher) {
+    let mut lim = GCRA::for_capacity(50).cell_weight(1).build_sync();
+    let now = Instant::now();
+    let ms = Duration::from_millis(20);
+    let mut children = vec![];
+
+    lim.check_at(now).unwrap();
+    for _i in 0..19 {
+        let mut lim = lim.clone();
+        let mut b = b.clone();
+        children.push(thread::spawn(move || {
+            let mut i = 0;
+            b.iter(|| {
+                i += 1;
+                lim.check_at(now + (ms * i)).unwrap();
+            });
+        }));
+    }
+    let mut i = 0;
+    b.iter(|| {
+        i += 1;
+        lim.check_at(now + (ms * i)).unwrap();
+    });
+    for child in children {
+        child.join().unwrap();
+    }
+}

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -6,7 +6,6 @@ extern crate ratelimit_meter;
 use ratelimit_meter::{GCRA, Threadsafe, Decider};
 use ratelimit_meter::example_algorithms::Allower;
 use std::time::{Instant, Duration};
-use std::thread;
 
 #[bench]
 fn bench_gcra(b: &mut test::Bencher) {
@@ -43,29 +42,4 @@ fn bench_threadsafe_allower(b: &mut test::Bencher) {
     let allower_one = Allower::new();
     let mut threadsafe_allower = Threadsafe::new(allower_one);
     b.iter(|| threadsafe_allower.check());
-}
-
-// This one doesn't seem to actually do a thing & I can't quite figure out why /:
-#[bench]
-fn bench_multithreading_potentially_buggy(b: &mut test::Bencher) {
-    let mut lim = GCRA::for_capacity(50).cell_weight(1).build_sync();
-    let now = Instant::now();
-    let ms = Duration::from_millis(20);
-    let mut children = vec![];
-
-    lim.check_at(now).unwrap();
-    for _i in 0..20 {
-        let mut lim = lim.clone();
-        let mut b = b.clone();
-        children.push(thread::spawn(move || {
-            let mut i = 0;
-            b.iter(|| {
-                i += 1;
-                lim.check_at(now + (ms * i)).unwrap();
-            });
-        }));
-    }
-    for child in children {
-        child.join().unwrap();
-    }
 }

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -112,3 +112,9 @@ impl DeciderImpl for GCRA {
 }
 
 impl Decider for GCRA {}
+
+impl From<Builder> for GCRA {
+    fn from(b: Builder) -> Self {
+        b.build()
+    }
+}

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -1,4 +1,4 @@
-use {DeciderImpl, Decider, Decision, Limiter, ErrorKind, Result};
+use {DeciderImpl, Decider, Decision, Threadsafe, Result};
 
 use std::time::{Instant, Duration};
 use std::cmp;
@@ -15,9 +15,9 @@ use std::cmp;
 /// to the GCRA parameters τ=1s, T=50ms (that's 1s / 20 cells).
 ///
 /// ```
-/// # use ratelimit_meter::{Limiter, Decider, GCRA, Decision};
+/// # use ratelimit_meter::{Decider, GCRA, Decision};
 /// # use std::time::{Instant, Duration};
-/// let mut limiter = Limiter::new().capacity(20).weight(1).build::<GCRA>().unwrap();
+/// let mut limiter = GCRA::for_capacity(20).cell_weight(1).build();
 /// let now = Instant::now();
 /// let ms = Duration::from_millis(1);
 /// assert_eq!(Decision::Yes, limiter.check_at(now).unwrap()); // the first cell is free
@@ -41,6 +41,60 @@ pub struct GCRA {
     tat: Option<Instant>,
 }
 
+/// A builder object that can be used to construct rate-limiters as
+/// meters.
+pub struct Builder {
+    capacity: u32,
+    cell_weight: u32,
+    time_unit: Duration,
+}
+
+/// Constructs a concrete GCRA instance.
+impl Builder {
+    /// Sets the "weight" of each cell being checked against the
+    /// bucket. Each cell fills the bucket by this much.
+    pub fn cell_weight<'a>(&'a mut self, weight: u32) -> &'a mut Builder {
+        self.cell_weight = weight;
+        self
+    }
+
+    /// Sets the "unit of time" within which the bucket drains.
+    ///
+    /// The assumption is that in a period of `time_unit` (if no cells
+    /// are being checked), the bucket is fully drained.
+    pub fn per<'a>(&'a mut self, time_unit: Duration) -> &'a mut Builder {
+        self.time_unit = time_unit;
+        self
+    }
+
+    /// Builds and returns a thread-safe GCRA decider.
+    pub fn build_sync(&self) -> Threadsafe<GCRA> {
+        Threadsafe::new(self.build())
+    }
+
+    /// Builds a single-threaded GCRA decider.
+    pub fn build(&self) -> GCRA {
+        GCRA {
+            t: (self.time_unit / self.capacity) * self.cell_weight,
+            tau: self.time_unit,
+            tat: None,
+        }
+    }
+}
+
+impl GCRA {
+    /// Constructs a builder object for a GCRA rate-limiter with the
+    /// given capacity per second, at cell weight=1. See
+    /// [`Builder`](struct.Builder.html) for options.
+    pub fn for_capacity(capacity: u32) -> Builder {
+        Builder {
+            capacity: capacity,
+            cell_weight: 1,
+            time_unit: Duration::from_secs(1),
+        }
+    }
+}
+
 impl DeciderImpl for GCRA {
     /// In GCRA, negative decisions come with the time at which the
     /// next cell was expected to arrive; client code of GCRA can use
@@ -54,19 +108,6 @@ impl DeciderImpl for GCRA {
         }
         self.tat = Some(cmp::max(tat, t0) + self.t);
         Ok(Decision::Yes)
-    }
-
-    fn build_with(l: &Limiter) -> Result<Self> {
-        let capacity = l.capacity.ok_or(ErrorKind::CapacityRequired)?;
-        let weight = l.weight.ok_or(ErrorKind::WeightRequired)?;
-        if l.time_unit <= Duration::new(0, 0) {
-            return Err(ErrorKind::InvalidTimeUnit(l.time_unit).into());
-        }
-        Ok(GCRA {
-            t: (l.time_unit / capacity) * weight,
-            tau: l.time_unit,
-            tat: None,
-        })
     }
 }
 

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -85,7 +85,7 @@ impl Builder {
 impl GCRA {
     /// Constructs a builder object for a GCRA rate-limiter with the
     /// given capacity per second, at cell weight=1. See
-    /// [`Builder`](struct.Builder.html) for options.
+    /// [`Builder`](gcra/struct.Builder.html) for options.
     pub fn for_capacity(capacity: u32) -> Builder {
         Builder {
             capacity: capacity,
@@ -113,8 +113,31 @@ impl DeciderImpl for GCRA {
 
 impl Decider for GCRA {}
 
+/// Allows converting from a GCRA builder directly into a
+/// GCRA decider. Same as
+/// [the borrowed implementation](#impl-From<&'a Builder>), except for
+/// owned `Builder`s.
+/// # Example:
+/// ```
+/// use ratelimit_meter::{GCRA, Decider, Decision};
+/// let mut gcra: GCRA = GCRA::for_capacity(50).into();
+/// assert_eq!(Decision::Yes, gcra.check().unwrap());
+/// ```
 impl From<Builder> for GCRA {
     fn from(b: Builder) -> Self {
+        b.build()
+    }
+}
+
+/// Allows converting a GCRA builder directly into a GCRA decider.
+/// # Example:
+/// ```
+/// use ratelimit_meter::{GCRA, Decider, Decision};
+/// let mut gcra: GCRA = GCRA::for_capacity(50).cell_weight(2).into();
+/// assert_eq!(Decision::Yes, gcra.check().unwrap());
+/// ```
+impl<'a> From<&'a mut Builder> for GCRA {
+    fn from(b: &'a mut Builder) -> Self {
         b.build()
     }
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,5 +1,5 @@
-mod gcra;
+pub mod gcra;
 mod threadsafe;
 
-pub use self::gcra::*;
+pub use self::gcra::GCRA;
 pub use self::threadsafe::*;

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -46,8 +46,26 @@ impl<Impl> Decider for Threadsafe<Impl>
 {
 }
 
+/// Allows converting from a GCRA builder directly into a threadsafe
+/// GCRA decider. For example:
+/// # Example
+/// ```
+/// use ratelimit_meter::{GCRA, Decider, Threadsafe, Decision};
+/// let mut gcra_sync: Threadsafe<GCRA> = GCRA::for_capacity(50).into();
+/// assert_eq!(Decision::Yes, gcra_sync.check().unwrap());
+/// ```
 impl<'a> From<&'a Builder> for Threadsafe<GCRA> {
     fn from(b: &'a Builder) -> Self {
+        b.build_sync()
+    }
+}
+
+/// Allows converting from a GCRA builder directly into a threadsafe
+/// GCRA decider. Same as
+/// [the borrowed implementation](#impl-From<&'a Builder>), except for
+/// owned `Builder`s.
+impl<'a> From<Builder> for Threadsafe<GCRA> {
+    fn from(b: Builder) -> Self {
         b.build_sync()
     }
 }

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -1,4 +1,4 @@
-use {DeciderImpl, Decider, Decision, Limiter, Result};
+use {DeciderImpl, Decider, Decision, Result};
 
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -17,6 +17,15 @@ pub struct Threadsafe<Impl>
     sub: Arc<Mutex<Impl>>,
 }
 
+impl<Impl> Threadsafe<Impl>
+    where Impl: Sized,
+          Impl: Clone
+{
+    pub fn new(sub: Impl) -> Threadsafe<Impl> {
+        Threadsafe { sub: Arc::new(Mutex::new(sub)) }
+    }
+}
+
 impl<Impl> DeciderImpl for Threadsafe<Impl>
     where Impl: Decider,
           Impl: Sized,
@@ -27,10 +36,6 @@ impl<Impl> DeciderImpl for Threadsafe<Impl>
     fn test_and_update(&mut self, at: Instant) -> Result<Decision<Impl::T>> {
         self.sub.lock()?.test_and_update(at)
     }
-
-    fn build_with(l: &Limiter) -> Result<Self> {
-        Ok(Threadsafe { sub: Arc::new(Mutex::new(Impl::build_with(l)?)) })
-    }
 }
 
 impl<Impl> Decider for Threadsafe<Impl>
@@ -38,5 +43,4 @@ impl<Impl> Decider for Threadsafe<Impl>
           Impl: Sized,
           Impl: Clone
 {
-
 }

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -1,4 +1,5 @@
 use {DeciderImpl, Decider, Decision, Result};
+use algorithms::gcra::{GCRA, Builder};
 
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -43,4 +44,10 @@ impl<Impl> Decider for Threadsafe<Impl>
           Impl: Sized,
           Impl: Clone
 {
+}
+
+impl<'a> From<&'a Builder> for Threadsafe<GCRA> {
+    fn from(b: &'a Builder) -> Self {
+        b.build_sync()
+    }
 }

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -12,25 +12,23 @@ use std::time::Instant;
 /// in an atomically reference-counted mutex. It takes out a mutex
 /// whenever `.test_and_update()` is called.
 pub struct Threadsafe<Impl>
-    where Impl: Sized,
-          Impl: Clone
+    where Impl: Decider + Sized + Clone
 {
     sub: Arc<Mutex<Impl>>,
 }
 
 impl<Impl> Threadsafe<Impl>
-    where Impl: Sized,
-          Impl: Clone
+    where Impl: Decider + Sized + Clone
 {
+    // Returns a new Threadsafe wrapper for the given rate-limiting
+    // implementation object `sub`.
     pub fn new(sub: Impl) -> Threadsafe<Impl> {
         Threadsafe { sub: Arc::new(Mutex::new(sub)) }
     }
 }
 
 impl<Impl> DeciderImpl for Threadsafe<Impl>
-    where Impl: Decider,
-          Impl: Sized,
-          Impl: Clone
+    where Impl: Decider + Sized + Clone
 {
     type T = Impl::T;
 
@@ -40,9 +38,7 @@ impl<Impl> DeciderImpl for Threadsafe<Impl>
 }
 
 impl<Impl> Decider for Threadsafe<Impl>
-    where Impl: Decider,
-          Impl: Sized,
-          Impl: Clone
+    where Impl: Decider + Sized + Clone
 {
 }
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,25 +1,7 @@
 use std::sync::{MutexGuard, PoisonError};
-use std::time::Duration;
 
 error_chain! {
     errors {
-        /// Returned if the rate limiter implementation requires a
-        /// capacity for the "bucket".
-        CapacityRequired {
-            display("a capacity is required")
-        }
-
-        /// Returned if the rate limiter implementation requires a
-        /// weight per unit of work.
-        WeightRequired {
-            display("a weight is required")
-        }
-
-        /// Returned if the drainage time unit is wrong (e.g. it's negative).
-        InvalidTimeUnit(u: Duration) {
-            display("time unit {:?} is invalid", u)
-        }
-
         /// Returned when attempting to acquire a "poisoned" mutex.
         ThreadingError {
             display("mutex is poisoned")

--- a/src/example_algorithms.rs
+++ b/src/example_algorithms.rs
@@ -1,4 +1,4 @@
-use {DeciderImpl, Decider, Decision, Limiter, Result};
+use {DeciderImpl, Decider, Decision, Result};
 
 use std::time::Instant;
 
@@ -7,6 +7,12 @@ use std::time::Instant;
 /// The most naive implementation of a rate-limiter ever: Always
 /// allows every cell through.
 pub struct Allower {}
+
+impl Allower {
+    pub fn new() -> Allower {
+        Allower {}
+    }
+}
 
 impl DeciderImpl for Allower {
     /// Allower never returns a negative answer, so negative answers
@@ -17,12 +23,6 @@ impl DeciderImpl for Allower {
     fn test_and_update(&mut self, _t0: Instant) -> Result<Decision<()>> {
         Ok(Decision::Yes)
     }
-
-    /// Builds the most useless rate-limiter in existence.
-    fn build_with(_l: &Limiter) -> Result<Self> {
-        Ok(Allower {})
-    }
 }
 
-impl Decider for Allower {
-}
+impl Decider for Allower {}

--- a/src/example_algorithms.rs
+++ b/src/example_algorithms.rs
@@ -6,6 +6,13 @@ use std::time::Instant;
 #[derive(Copy, Clone)]
 /// The most naive implementation of a rate-limiter ever: Always
 /// allows every cell through.
+/// # Example
+/// ```
+/// use ratelimit_meter::{Decider};
+/// use ratelimit_meter::example_algorithms::Allower;
+/// let mut allower = Allower::new();
+/// assert!(allower.check().unwrap().is_compliant());
+/// ```
 pub struct Allower {}
 
 impl Allower {

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -5,7 +5,7 @@ use std::time::{Instant, Duration};
 
 #[test]
 fn accepts_first_cell() {
-    let mut gcra = GCRA::for_capacity(5).build();
+    let mut gcra: GCRA = GCRA::for_capacity(5).into();
     assert_eq!(Decision::Yes, gcra.check().unwrap());
 }
 #[test]

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -1,24 +1,24 @@
 extern crate ratelimit_meter;
 
-use ratelimit_meter::{GCRA, Limiter, Decider, Decision};
+use ratelimit_meter::{GCRA, Decider, Decision};
 use std::time::{Instant, Duration};
 
 #[test]
 fn accepts_first_cell() {
-    let mut gcra = Limiter::new().capacity(5).weight(1).build::<GCRA>().unwrap();
+    let mut gcra = GCRA::for_capacity(5).build();
     assert_eq!(Decision::Yes, gcra.check().unwrap());
 }
 #[test]
 fn rejects_too_many() {
-    let mut gcra = Limiter::new().capacity(1).weight(1).build::<GCRA>().unwrap();
+    let mut gcra = GCRA::for_capacity(1).build();
     let now = Instant::now();
     gcra.check_at(now).unwrap();
     gcra.check_at(now).unwrap();
-    assert_ne!(Decision::Yes, gcra.check_at(now).unwrap());
+    assert_ne!(Decision::Yes, gcra.check_at(now).unwrap(), "{:?}", gcra);
 }
 #[test]
 fn allows_after_interval() {
-    let mut gcra = Limiter::new().capacity(1).weight(1).build::<GCRA>().unwrap();
+    let mut gcra = GCRA::for_capacity(1).build();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
     gcra.check_at(now).unwrap();

--- a/tests/threadsafe.rs
+++ b/tests/threadsafe.rs
@@ -1,26 +1,18 @@
 extern crate ratelimit_meter;
 
-use ratelimit_meter::{GCRA, Threadsafe, Limiter, Decider, Decision};
+use ratelimit_meter::{GCRA, Decider, Decision};
 use std::thread;
 use std::time::{Instant, Duration};
 
 #[test]
 fn simple_operation() {
-    let mut lim = Limiter::new()
-        .capacity(5)
-        .weight(1)
-        .build::<Threadsafe<GCRA>>()
-        .unwrap();
+    let mut lim = GCRA::for_capacity(5).build_sync();
     assert_eq!(Decision::Yes, lim.check().unwrap());
 }
 
 #[test]
 fn actual_threadsafety() {
-    let mut lim = Limiter::new()
-        .capacity(20)
-        .weight(1)
-        .build::<Threadsafe<GCRA>>()
-        .unwrap();
+    let mut lim = GCRA::for_capacity(20).build_sync();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
     let mut children = vec![];


### PR DESCRIPTION
This is for 0.3.0: The constructors I'd defined at the start of this project are too generic and simultaneously straight-jacket-y. There's no need for them to return `Result`, as everything has reasonable defaults.

So, let's make the constructor interface better: 
* Give `Allower` and `Threadsafe` a `::new()` function.
* Specialize the Builder pattern to `GCRA`.
* Implement `From` for various conversions.

The result is a much nicer-looking experience. Witness [the test code](https://github.com/antifuchs/ratelimit_meter/compare/constructors#diff-ae9e4acc3dc65d9db58a4ce016144d55L13), for example.