### PR TITLE
Implement #5: Multi-cell decision making

### DIFF
--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -10,7 +10,7 @@ use std::thread;
 
 #[bench]
 fn bench_20threads(b: &mut test::Bencher) {
-    let mut lim = GCRA::for_capacity(50).cell_weight(1).build_sync();
+    let mut lim = GCRA::for_capacity(50).unwrap().cell_weight(1).unwrap().build_sync();
     let now = Instant::now();
     let ms = Duration::from_millis(20);
     let mut children = vec![];

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -9,7 +9,7 @@ use std::time::{Instant, Duration};
 
 #[bench]
 fn bench_gcra(b: &mut test::Bencher) {
-    let mut gcra = GCRA::for_capacity(50).cell_weight(1).build();
+    let mut gcra = GCRA::for_capacity(50).unwrap().cell_weight(1).unwrap().build();
     let now = Instant::now();
     let ms = Duration::from_millis(20);
     let mut i = 0;
@@ -27,7 +27,7 @@ fn bench_allower(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_threadsafe_gcra(b: &mut test::Bencher) {
-    let mut gcra = GCRA::for_capacity(50).cell_weight(1).build_sync();
+    let mut gcra = GCRA::for_capacity(50).unwrap().cell_weight(1).unwrap().build_sync();
     let now = Instant::now();
     let ms = Duration::from_millis(20);
     let mut i = 0;

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -3,7 +3,7 @@
 extern crate test;
 extern crate ratelimit_meter;
 
-use ratelimit_meter::{GCRA, Threadsafe, Decider};
+use ratelimit_meter::{GCRA, Threadsafe, Decider, MultiDecider};
 use ratelimit_meter::example_algorithms::Allower;
 use std::time::{Instant, Duration};
 
@@ -16,6 +16,18 @@ fn bench_gcra(b: &mut test::Bencher) {
     b.iter(|| {
         i += 1;
         gcra.check_at(now + (ms * i)).unwrap();
+    });
+}
+
+#[bench]
+fn bench_gcra_bulk(b: &mut test::Bencher) {
+    let mut gcra = GCRA::for_capacity(500).unwrap().cell_weight(1).unwrap().build();
+    let now = Instant::now();
+    let ms = Duration::from_millis(20);
+    let mut i = 0;
+    b.iter(|| {
+        i += 1;
+        gcra.check_n_at(10, now + (ms * i)).unwrap();
     });
 }
 

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -9,6 +9,28 @@ use std::cmp;
 /// Traffic control and congestion control in B-ISDN; from
 /// [Wikipedia](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm).
 ///
+///
+/// While algorithms like leaky-bucket rate limiters allow cells to be
+/// distributed across time in any way, GCRA is a rate-limiting *and*
+/// traffic-shaping algorithm. It mandates that a minimum amount of
+/// time passes between cells being measured. For example, if your API
+/// mandates that only 20 requests can be made per second, GCRA will
+/// ensure that each request is at least 50ms apart from the previous
+/// request. This makes GCRA suitable for shaping traffic in
+/// networking and telecom equipment (it was initially made for
+/// asynchronous transfer mode networks), or for outgoing workloads on
+/// *consumers* of attention, e.g. distributing outgoing emails across
+/// a day.
+///
+/// In a blatant side-stepping of the above traffic-shaping criteria,
+/// this implementation of GCRA comes with an extension that allows
+/// measuring multiple cells at once, assuming that if a pause of
+/// `n*(the minimum time between cells)` has passed, we can allow a
+/// single big batch of `n` cells through. This assumption may not be
+/// correct for your application, but if you depend on GCRA's
+/// traffic-shaping properties, it's better to not use the `_n`
+/// suffixed check functions.
+///
 /// # Example
 /// In this example, we construct a rate-limiter with the GCR
 /// algorithm that can accomodate 20 cells per second. This translates

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -121,6 +121,15 @@ impl GCRA {
             time_unit: Duration::from_secs(1),
         })
     }
+
+    /// Constructs a GCRA rate-limiter with the parameters T (the
+    /// minimum amount of time that single cells are spaced apart),
+    /// tau (τ, the number of cells that fit into this buffer), and an
+    /// optional t_at (the earliest instant that the rate-limiter
+    /// would accept another cell).
+    pub fn with_parameters(t: Duration, tau: Duration, tat: Option<Instant>) -> GCRA {
+        GCRA{t: t, tau: tau, tat: tat}
+    }
 }
 
 impl Decider for GCRA {}

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -235,3 +235,28 @@ impl<'a> From<&'a mut Builder> for GCRA {
         b.build()
     }
 }
+
+/// Allows converting a GCRA into a tuple containing its T (the
+/// minimum amount of time that single cells are spaced apart), tau
+/// (τ, the number of cells that fit into this buffer), and an
+/// optional t_at (the earliest instant that the rate-limiter would
+/// accept another cell).
+///
+/// These parameters can be used with
+/// [`.with_parameters`](#method.with_parameters) to persist and
+/// construct a copy of the GCRA rate-limiter.
+impl<'a> Into<(Duration, Duration, Option<Instant>)> for &'a GCRA {
+    fn into(self) -> (Duration, Duration, Option<Instant>) {
+        (self.t, self.tau, self.tat)
+    }
+}
+
+/// Allows converting the parameters returned from
+/// [`Into<(Duration, Duration, Option<Instant>)>`](#impl-Into<(Duration, Duration, Option<Instant>)>)
+/// back into a GCRA.
+impl From<(Duration, Duration, Option<Instant>)> for GCRA {
+    fn from(params: (Duration, Duration, Option<Instant>)) -> GCRA {
+        let (t, tau, tat) = params;
+        GCRA::with_parameters(t, tau, tat)
+    }
+}

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -51,7 +51,7 @@ impl<Impl> Decider for Threadsafe<Impl>
 /// # Example
 /// ```
 /// use ratelimit_meter::{GCRA, Decider, Threadsafe, Decision};
-/// let mut gcra_sync: Threadsafe<GCRA> = GCRA::for_capacity(50).into();
+/// let mut gcra_sync: Threadsafe<GCRA> = GCRA::for_capacity(50).unwrap().into();
 /// assert_eq!(Decision::Yes, gcra_sync.check().unwrap());
 /// ```
 impl<'a> From<&'a Builder> for Threadsafe<GCRA> {

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -35,6 +35,10 @@ impl<Impl> DeciderImpl for Threadsafe<Impl>
     fn test_and_update(&mut self, at: Instant) -> Result<Decision<Impl::T>> {
         self.sub.lock()?.test_and_update(at)
     }
+
+    fn test_n_and_update(&mut self, n: u32, at: Instant) -> Result<Decision<Impl::T>> {
+        self.sub.lock()?.test_n_and_update(n, at)
+    }
 }
 
 impl<Impl> Decider for Threadsafe<Impl>

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -1,4 +1,4 @@
-use {DeciderImpl, Decider, Decision, Result};
+use {MultiDeciderImpl, DeciderImpl, TypedDecider, Decider, Decision, Result};
 use algorithms::gcra::{GCRA, Builder};
 
 use std::sync::{Arc, Mutex};
@@ -27,15 +27,19 @@ impl<Impl> Threadsafe<Impl>
     }
 }
 
+impl<Impl> TypedDecider for Threadsafe<Impl> where Impl: TypedDecider + Decider + Sized + Clone {
+    type T = Impl::T;
+}
+
 impl<Impl> DeciderImpl for Threadsafe<Impl>
     where Impl: Decider + Sized + Clone
 {
-    type T = Impl::T;
-
     fn test_and_update(&mut self, at: Instant) -> Result<Decision<Impl::T>> {
         self.sub.lock()?.test_and_update(at)
     }
+}
 
+impl <Impl> MultiDeciderImpl for Threadsafe<Impl> where Impl: MultiDeciderImpl + Decider + Sized + Clone {
     fn test_n_and_update(&mut self, n: u32, at: Instant) -> Result<Decision<Impl::T>> {
         self.sub.lock()?.test_n_and_update(n, at)
     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -2,16 +2,26 @@ use std::sync::{MutexGuard, PoisonError};
 
 error_chain! {
     errors {
-        /// Returned when attempting to acquire a "poisoned" mutex.
+        /// Returned when attempting to acquire a "poisoned"
+        /// mutex. Due to limitations in error_chain, this error kind
+        /// does not contain the original mutex guard or the piece of
+        /// data that was meant to be locked.
         ThreadingError {
             display("mutex is poisoned")
         }
 
-        /// Returned when an internal inconsistency is detected
-        /// (e.g. a bucket's capacity is too small to accomodate a
-        /// single cell)
-        CapacityError {
-            display("bucket capacity is wrong")
+        /// Returned when constructing a bucket is impossible: when
+        /// the capacity is 0, or the weight of a single cell is
+        /// larger than the bucket's capacity.
+        InconsistentCapacity(capacity: u32, weight: u32) {
+            display("bucket capacity {} is not enough to accomodate even a single cell with weight {}",
+                    capacity, weight)
+        }
+
+        /// Returned when trying to check more cells than the bucket
+        /// can accomodate, given its capacity and per-cell weight.
+        InsufficientCapacity(n: u32) {
+            display("bucket does not have enough capacity to accomodate {} cells", n)
         }
     }
 }
@@ -19,8 +29,7 @@ error_chain! {
 /// This must discard the original PoisonError, as `error_chain` does
 /// not currently support parameterizing `foreign_link`s with types
 /// the way we would need to.
-impl<'a, T> ::std::convert::From<PoisonError<MutexGuard<'a, T>>> for Error
-{
+impl<'a, T> ::std::convert::From<PoisonError<MutexGuard<'a, T>>> for Error {
     fn from(_err: PoisonError<MutexGuard<'a, T>>) -> Self {
         ErrorKind::ThreadingError.into()
     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,6 +6,13 @@ error_chain! {
         ThreadingError {
             display("mutex is poisoned")
         }
+
+        /// Returned when an internal inconsistency is detected
+        /// (e.g. a bucket's capacity is too small to accomodate a
+        /// single cell)
+        CapacityError {
+            display("bucket capacity is wrong")
+        }
     }
 }
 

--- a/src/example_algorithms.rs
+++ b/src/example_algorithms.rs
@@ -26,8 +26,8 @@ impl DeciderImpl for Allower {
     /// don't carry information.
     type T = ();
 
-    /// Allows the cell through unconditionally.
-    fn test_and_update(&mut self, _t0: Instant) -> Result<Decision<()>> {
+    /// Allows all cells through unconditionally.
+    fn test_n_and_update(&mut self, _n: u32, _t0: Instant) -> Result<Decision<()>> {
         Ok(Decision::Yes)
     }
 }

--- a/src/example_algorithms.rs
+++ b/src/example_algorithms.rs
@@ -1,4 +1,4 @@
-use {DeciderImpl, Decider, Decision, Result};
+use {MultiDeciderImpl, TypedDecider, ImpliedDeciderImpl, MultiDecider, Decider, Decision, Result};
 
 use std::time::Instant;
 
@@ -21,15 +21,20 @@ impl Allower {
     }
 }
 
-impl DeciderImpl for Allower {
+impl TypedDecider for Allower {
     /// Allower never returns a negative answer, so negative answers
     /// don't carry information.
     type T = ();
+}
 
+impl MultiDeciderImpl for Allower {
     /// Allows all cells through unconditionally.
     fn test_n_and_update(&mut self, _n: u32, _t0: Instant) -> Result<Decision<()>> {
         Ok(Decision::Yes)
     }
 }
 
+impl ImpliedDeciderImpl for Allower {}
+
 impl Decider for Allower {}
+impl MultiDecider for Allower {}

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -1,0 +1,51 @@
+use {Decision, Result, TypedDecider};
+use std::time::Instant;
+
+/// The trait that implementations of the metered rate-limiter
+/// interface have to implement. Users of this library should rely on
+/// [Decider](trait.Decider.html) for the external interface.
+pub trait DeciderImpl : TypedDecider {
+    /// Tests if a single cell can be accomodated in the rate limiter
+    /// at the instant `at` and updates the rate-limiter to account
+    /// for the weight of the cell.
+    ///
+    /// This method is not meant to be called by users, see instead
+    /// the [Decider trait](trait.Decider.html). The default
+    /// implementation only calls
+    /// [`test_n_and_update`](#test_n_and_update).
+    fn test_and_update(&mut self, at: Instant) -> Result<Decision<Self::T>>;
+}
+
+/// The trait that a metered rate-limiter interface has to implement
+/// to support decisions on multiple cells in a batch.
+pub trait MultiDeciderImpl: TypedDecider {
+    /// Tests if `n` cells can be accomodated in the rate limiter at
+    /// the instant `at` and updates the rate-limiter to account for
+    /// the weight of the cells and updates the ratelimiter state.
+    ///
+    /// The update is all or nothing: Unless all n cells can be
+    /// accomodated, the state of the rate limiter will not be
+    /// updated.
+    ///
+    /// This method is not meant to be called by users, see instead
+    /// [the `Decider` trait](trait.Decider.html).
+    fn test_n_and_update(&mut self, n: u32, at: Instant) -> Result<Decision<Self::T>>;
+}
+
+/// A trait that some implementations can opt into, to get a default
+/// implementation of the DeciderImpl trait.
+pub trait ImpliedDeciderImpl: TypedDecider + MultiDeciderImpl {}
+
+/// A default implementation of the Decider trait, using the
+/// MultiDeciderImpl trait's methods with `n=1`.
+impl<T> DeciderImpl for T
+    where T: ImpliedDeciderImpl
+{
+    /// Default implementation of
+    /// [trait.DeciderImpl.html#tymethod.test_and_update]`test_and_update`,
+    /// calling [`test_n_and_update`](tymethod.test_n_and_update) with
+    /// `n=1`.
+    fn test_and_update(&mut self, at: Instant) -> Result<Decision<Self::T>> {
+        self.test_n_and_update(1, at)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,16 @@
 //! should use the `Instant` returned with negative decisions and wait
 //! in your own, e.g. event loop.
 //!
-//! ## Design and implementation
+//! ## Design and implementation of GCRA
 //!
-//! Unlike some other token bucket algorithms, the GCRA one assumes that
-//! all units of work are of the same "weight", and so allows some
-//! optimizations which result in much more consise and fast code (it does
-//! not even use multiplication or division in the "hot" path).
+//! Unlike token bucket algorithms, the GCRA one assumes that all
+//! units of work are of the same "weight", and so allows some
+//! optimizations which result in much more consise and fast code (it
+//! does not even use multiplication or division in the "hot" path).
 //!
-//! The trade-off here this is that there is currently no support for
-//! assigning different weights to incoming cells (say, particularly
-//! heavy api calls vs. lightweight ones) using the same rate-limiter
-//! structure.
+//! See [the documentation of the GCRA type](struct.GCRA.html) for
+//! more details on its implementation and on trade-offs that apply to
+//! it.
 //!
 //! ## Thread-safe operation
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //! use std::time::Duration;
 //! use ratelimit_meter::{Decider, GCRA, Decision};
 //!
-//! let mut lim = GCRA::for_capacity(50) // Allow 50 units of work
+//! let mut lim = GCRA::for_capacity(50).unwrap() // Allow 50 units of work
 //!     .per(Duration::from_secs(1)) // We calculate per-second (this is the default).
-//!     .cell_weight(1) // Each cell is one unit of work "heavy".
+//!     .cell_weight(1).unwrap() // Each cell is one unit of work "heavy".
 //!     .build(); // Construct a non-threadsafe GCRA decider.
 //! assert_eq!(Decision::Yes, lim.check().unwrap());
 //! ```
@@ -59,9 +59,9 @@
 //! use std::time::Duration;
 //! use ratelimit_meter::{Decider, GCRA, Decision};
 //!
-//! let mut lim = GCRA::for_capacity(50) // Allow 50 units of work
+//! let mut lim = GCRA::for_capacity(50).unwrap() // Allow 50 units of work
 //!     .per(Duration::from_secs(1)) // We calculate per-second (this is the default).
-//!     .cell_weight(1) // Each cell is one unit of work "heavy".
+//!     .cell_weight(1).unwrap() // Each cell is one unit of work "heavy".
 //!     .build_sync(); // Construct a threadsafe GCRA decider.
 //! assert_eq!(Decision::Yes, lim.check().unwrap());
 //! ```

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -34,11 +34,14 @@ fn allows_n_after_interval() {
     let mut gcra = GCRA::for_capacity(2).build();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
-    assert_eq!(Decision::Yes, gcra.check_n_at(3, now).unwrap());
+    assert_eq!(Decision::Yes, gcra.check_n_at(2, now).unwrap());
     assert!(!gcra.check_n_at(2, now+ms*1).unwrap().is_compliant());
-    // should be ok again in 1s:
+    // should be ok again in 1.5s:
     let next = now + Duration::from_secs(1);
-    assert_eq!(Decision::Yes, gcra.check_n_at(2, next).unwrap());
+    assert_eq!(Decision::Yes, gcra.check_n_at(2, next).unwrap(), "now: {:?}", next);
+
+    // should always accomodate 0 cells:
+    assert_eq!(Decision::Yes, gcra.check_n_at(0, next).unwrap());
 }
 
 #[test]

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -1,6 +1,6 @@
 extern crate ratelimit_meter;
 
-use ratelimit_meter::{GCRA, Decider, Decision};
+use ratelimit_meter::{GCRA, Decider, Decision, ErrorKind, Error};
 use std::time::{Instant, Duration};
 
 #[test]
@@ -27,4 +27,35 @@ fn allows_after_interval() {
     // should be ok again in 1s:
     let next = now + Duration::from_secs(1);
     assert_eq!(Decision::Yes, gcra.check_at(next).unwrap());
+}
+
+#[test]
+fn allows_n_after_interval() {
+    let mut gcra = GCRA::for_capacity(2).build();
+    let now = Instant::now();
+    let ms = Duration::from_millis(1);
+    assert_eq!(Decision::Yes, gcra.check_n_at(3, now).unwrap());
+    assert!(!gcra.check_n_at(2, now+ms*1).unwrap().is_compliant());
+    // should be ok again in 1s:
+    let next = now + Duration::from_secs(1);
+    assert_eq!(Decision::Yes, gcra.check_n_at(2, next).unwrap());
+}
+
+#[test]
+fn never_allows_more_than_capacity() {
+    let mut gcra = GCRA::for_capacity(5).build();
+    let now = Instant::now();
+    let ms = Duration::from_millis(1);
+
+    // Should not allow the first 15 cells on a capacity 5 bucket:
+    assert!(gcra.check_n_at(15, now).is_err());
+
+    // After 3 and 20 seconds, it should not allow 15 on that bucket either:
+    assert!(gcra.check_n_at(15, now+(ms*3*1000)).is_err());
+
+    let result = gcra.check_n_at(15, now+(ms*20*1000));
+    match result {
+        Err(Error(ErrorKind::CapacityError, _)) => (),
+        _ => panic!("Did not expect {:?}", result)
+    }
 }

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -5,12 +5,12 @@ use std::time::{Instant, Duration};
 
 #[test]
 fn accepts_first_cell() {
-    let mut gcra: GCRA = GCRA::for_capacity(5).into();
+    let mut gcra: GCRA = GCRA::for_capacity(5).unwrap().into();
     assert_eq!(Decision::Yes, gcra.check().unwrap());
 }
 #[test]
 fn rejects_too_many() {
-    let mut gcra = GCRA::for_capacity(1).build();
+    let mut gcra = GCRA::for_capacity(1).unwrap().build();
     let now = Instant::now();
     gcra.check_at(now).unwrap();
     gcra.check_at(now).unwrap();
@@ -18,7 +18,7 @@ fn rejects_too_many() {
 }
 #[test]
 fn allows_after_interval() {
-    let mut gcra = GCRA::for_capacity(1).build();
+    let mut gcra = GCRA::for_capacity(1).unwrap().build();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
     gcra.check_at(now).unwrap();
@@ -31,7 +31,7 @@ fn allows_after_interval() {
 
 #[test]
 fn allows_n_after_interval() {
-    let mut gcra = GCRA::for_capacity(2).build();
+    let mut gcra = GCRA::for_capacity(2).unwrap().build();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
     assert_eq!(Decision::Yes, gcra.check_n_at(2, now).unwrap());
@@ -46,7 +46,7 @@ fn allows_n_after_interval() {
 
 #[test]
 fn never_allows_more_than_capacity() {
-    let mut gcra = GCRA::for_capacity(5).build();
+    let mut gcra = GCRA::for_capacity(5).unwrap().build();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
 
@@ -58,7 +58,9 @@ fn never_allows_more_than_capacity() {
 
     let result = gcra.check_n_at(15, now+(ms*20*1000));
     match result {
-        Err(Error(ErrorKind::CapacityError, _)) => (),
+        Err(Error(ErrorKind::InsufficientCapacity(n), _)) => {
+            assert_eq!(n, 15)
+        },
         _ => panic!("Did not expect {:?}", result)
     }
 }

--- a/tests/gcra.rs
+++ b/tests/gcra.rs
@@ -1,6 +1,6 @@
 extern crate ratelimit_meter;
 
-use ratelimit_meter::{GCRA, Decider, Decision, ErrorKind, Error};
+use ratelimit_meter::{GCRA, MultiDecider, Decider, Decision, ErrorKind, Error};
 use std::time::{Instant, Duration};
 
 #[test]

--- a/tests/threadsafe.rs
+++ b/tests/threadsafe.rs
@@ -6,13 +6,13 @@ use std::time::{Instant, Duration};
 
 #[test]
 fn simple_operation() {
-    let mut lim = GCRA::for_capacity(5).build_sync();
+    let mut lim = GCRA::for_capacity(5).unwrap().build_sync();
     assert_eq!(Decision::Yes, lim.check().unwrap());
 }
 
 #[test]
 fn actual_threadsafety() {
-    let mut lim = GCRA::for_capacity(20).build_sync();
+    let mut lim = GCRA::for_capacity(20).unwrap().build_sync();
     let now = Instant::now();
     let ms = Duration::from_millis(1);
     let mut children = vec![];


### PR DESCRIPTION
The GCRA doesn't exactly lend itself to multi-cell decisions (you could say it actively resists), but here's an implementation of this anyway, with a bunch of restructuring of how implementing a thing works vs. how the external interface looks, for #5 

This comes with a few backwards-incompatible changes:

* `test_and_update` and the `DeciderImpl` interface are no longer publicly exported from the crate.
* the `Builder` `.cell_weight` and the `GCRA` `.for_capacity` methods now return `Result`s, as they can fail.