### PR TITLE
Lockfree data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 error-chain = "0.11.0-rc.2"
+crossbeam = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -23,32 +23,45 @@ Find them [on docs.rs](https://docs.rs/ratelimit_meter/) for the latest version!
 Unlike some other token bucket algorithms, the GCRA one assumes that
 all units of work are of the same "weight", and so allows some
 optimizations which result in much more concise and fast code (it does
-not even use multiplication or division in the "hot" path).
+not even use multiplication or division in the "hot" path for a
+single-cell decision).
 
-The downside of this is that there is currently no support for
-assigning different weights to cells.
-
-On the other hand, look at those benchmarks:
+All rate-limiting algorithm implementations in this crate are
+thread-safe and lock-free. Here are some benchmarks for repeated
+decisions (run on my macbook pro, this will differ on your hardware,
+etc etc):
 
 ```
 $ cargo bench
-   Compiling ratelimit_meter v0.1.0 (file:///Users/asf/Hacks/ratelimit_meter)
-    Finished release [optimized] target(s) in 1.54 secs
-     Running /Users/asf/Hacks/ratelimit_meter/target/release/deps/ratelimit_meter-a024ab042ec7d80c
+   Compiling ratelimit_meter v0.4.1 (file:///Users/asf/Hacks/ratelimit_meter)
+    Finished release [optimized] target(s) in 1.71 secs
+     Running target/release/deps/ratelimit_meter-680be7c7547f40f9
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
-     Running /Users/asf/Hacks/ratelimit_meter/target/release/deps/benchmarks-c150c61d51206d3c
+     Running target/release/deps/multi_threaded-b206ea78b9fc87cc
 
-running 4 tests
-test bench_allower            ... bench:          22 ns/iter (+/- 4)
-test bench_gcra               ... bench:          65 ns/iter (+/- 10)
-test bench_threadsafe_allower ... bench:          49 ns/iter (+/- 10)
-test bench_threadsafe_gcra    ... bench:          84 ns/iter (+/- 36)
+running 2 tests
+test bench_gcra_20threads         ... bench:         185 ns/iter (+/- 71)
+test bench_leaky_bucket_20threads ... bench:         667 ns/iter (+/- 16,193)
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
+test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out
+
+     Running target/release/deps/single_threaded-18617cd4f9e09b0d
+
+running 8 tests
+test bench_allower                 ... bench:          26 ns/iter (+/- 4)
+test bench_gcra                    ... bench:         131 ns/iter (+/- 33)
+test bench_gcra_bulk               ... bench:         143 ns/iter (+/- 24)
+test bench_leaky_bucket            ... bench:         156 ns/iter (+/- 27)
+test bench_leaky_bucket_bulk       ... bench:         152 ns/iter (+/- 24)
+test bench_threadsafe_allower      ... bench:          50 ns/iter (+/- 8)
+test bench_threadsafe_gcra         ... bench:         133 ns/iter (+/- 21)
+test bench_threadsafe_leaky_bucket ... bench:         154 ns/iter (+/- 47)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out
 ```
 
 ## Contributions welcome!

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -7,7 +7,7 @@ use ratelimit_meter::{GCRA, LeakyBucket, Decider};
 use std::time::{Instant, Duration};
 use std::thread;
 
-
+#[allow(deprecated)]
 #[bench]
 fn bench_gcra_20threads(b: &mut test::Bencher) {
     let mut lim = GCRA::for_capacity(50)
@@ -41,6 +41,7 @@ fn bench_gcra_20threads(b: &mut test::Bencher) {
     }
 }
 
+#[allow(deprecated)]
 #[bench]
 fn bench_leaky_bucket_20threads(b: &mut test::Bencher) {
     let mut lim = LeakyBucket::per_second(50).unwrap().threadsafe();

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -3,6 +3,7 @@
 extern crate test;
 extern crate ratelimit_meter;
 
+#[allow(deprecated)]
 use ratelimit_meter::{LeakyBucket, GCRA, Threadsafe, Decider, MultiDecider};
 use ratelimit_meter::example_algorithms::Allower;
 use std::time::{Instant, Duration};
@@ -70,6 +71,7 @@ fn bench_allower(b: &mut test::Bencher) {
     b.iter(|| allower.check().unwrap());
 }
 
+#[allow(deprecated)]
 #[bench]
 fn bench_threadsafe_gcra(b: &mut test::Bencher) {
     let mut gcra = GCRA::for_capacity(50)
@@ -98,6 +100,7 @@ fn bench_threadsafe_leaky_bucket(b: &mut test::Bencher) {
     });
 }
 
+#[allow(deprecated)]
 #[bench]
 fn bench_threadsafe_allower(b: &mut test::Bencher) {
     let allower_one = Allower::new();

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -1,7 +1,7 @@
 use {TypedDecider, DeciderImpl, MultiDeciderImpl, Decider, MultiDecider, Decision, Result,
      ErrorKind};
 
-use std::sync::atomic::Ordering::{Relaxed, Release};
+use std::sync::atomic::Ordering::{Relaxed, Acquire, Release};
 use std::time::{Instant, Duration};
 use std::cmp;
 use std::sync::Arc;
@@ -184,7 +184,7 @@ impl DeciderImpl for GCRA {
     fn test_and_update(&mut self, t0: Instant) -> Result<Decision<Instant>> {
         let guard = epoch::pin();
         loop {
-            let tat_there = self.tat.load(Relaxed, &guard);
+            let tat_there = self.tat.load(Acquire, &guard);
             let tat = match tat_there {
                 Some(sh) => **sh,
                 None => t0,
@@ -218,7 +218,7 @@ impl MultiDeciderImpl for GCRA {
     fn test_n_and_update(&mut self, n: u32, t0: Instant) -> Result<Decision<Instant>> {
         let guard = epoch::pin();
         loop {
-            let tat_there = self.tat.load(Relaxed, &guard);
+            let tat_there = self.tat.load(Acquire, &guard);
             let tat = match tat_there {
                 Some(sh) => **sh,
                 None => t0,

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -118,6 +118,7 @@ impl Builder {
         self
     }
 
+    #[deprecated = "GCRA is threadsafe by default, use .build()"]
     /// Builds and returns a lock-free, threadsafe GCRA decider. As
     /// there is no difference between this and the method
     /// [`build`](#method.build), this method is deprecated and will

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -194,11 +194,14 @@ impl DeciderImpl for GCRA {
                 return Ok(Decision::No(tat));
             }
             if self.tat
-                .cas_and_ref(tat_there,
-                             Owned::new(cmp::max(tat, t0) + self.t),
-                             Release,
-                             &guard)
-                .is_ok() {
+                .cas_and_ref(
+                    tat_there,
+                    Owned::new(cmp::max(tat, t0) + self.t),
+                    Release,
+                    &guard,
+                )
+                .is_ok()
+            {
                 return Ok(Decision::Yes);
             }
         }
@@ -241,11 +244,14 @@ impl MultiDeciderImpl for GCRA {
                 _ => self.t * n,
             };
             if self.tat
-                .cas_and_ref(tat_there,
-                             Owned::new(cmp::max(tat, t0) + additional_weight),
-                             Release,
-                             &guard)
-                .is_ok() {
+                .cas_and_ref(
+                    tat_there,
+                    Owned::new(cmp::max(tat, t0) + additional_weight),
+                    Release,
+                    &guard,
+                )
+                .is_ok()
+            {
                 return Ok(Decision::Yes);
             }
         }

--- a/src/algorithms/leaky_bucket.rs
+++ b/src/algorithms/leaky_bucket.rs
@@ -1,7 +1,7 @@
 use {TypedDecider, ImpliedDeciderImpl, MultiDeciderImpl, Decider, MultiDecider, Decision, Result,
      ErrorKind};
 
-use std::sync::atomic::Ordering::{Relaxed, Release};
+use std::sync::atomic::Ordering::{Acquire, Release};
 use std::time::{Instant, Duration};
 use std::cmp;
 use std::sync::Arc;
@@ -130,7 +130,7 @@ impl MultiDeciderImpl for LeakyBucket {
         let guard = epoch::pin();
 
         loop {
-            if let Some(state) = self.state.load(Relaxed, &guard) {
+            if let Some(state) = self.state.load(Acquire, &guard) {
                 let last = state.last_update.unwrap_or(t0);
                 // Prevent time travel: If any parallel calls get re-ordered,
                 // or any tests attempt silly things, make sure to answer from

--- a/src/algorithms/leaky_bucket.rs
+++ b/src/algorithms/leaky_bucket.rs
@@ -1,8 +1,12 @@
-use {TypedDecider, ImpliedDeciderImpl, MultiDeciderImpl, Decider, MultiDecider, Decision,
-     Threadsafe, Result, ErrorKind};
+use {TypedDecider, ImpliedDeciderImpl, MultiDeciderImpl, Decider, MultiDecider, Decision, Result,
+     ErrorKind};
 
+use std::sync::atomic::Ordering::{Relaxed, Release};
 use std::time::{Instant, Duration};
 use std::cmp;
+use std::sync::Arc;
+
+use crossbeam::epoch::{self, Atomic, Owned};
 
 impl Decider for LeakyBucket {}
 
@@ -40,6 +44,14 @@ impl TypedDecider for LeakyBucket {
 /// library must take care to apply positive jitter to these wait
 /// times.
 ///
+/// # Thread safety
+///
+/// This implementation uses lock-free techniques to safely update the
+/// bucket state in-place. This means the
+/// [`.threadsafe`](#method.threadsafe) method returns self & will be
+/// deprecated in a future release.
+///
+///
 /// # Example
 /// ``` rust
 /// # use ratelimit_meter::{Decider, LeakyBucket, Decision};
@@ -47,10 +59,15 @@ impl TypedDecider for LeakyBucket {
 /// assert_eq!(Decision::Yes, lb.check().unwrap());
 /// ```
 pub struct LeakyBucket {
-    last: Option<Instant>,
+    state: Arc<Atomic<BucketState>>,
     full: Duration,
-    current: Duration,
     token_interval: Duration,
+}
+
+#[derive(Debug, Clone)]
+struct BucketState {
+    level: Duration,
+    last_update: Option<Instant>,
 }
 
 impl LeakyBucket {
@@ -75,9 +92,12 @@ impl LeakyBucket {
             return Err(ErrorKind::InconsistentCapacity(capacity, 0).into());
         }
         let token_interval = per_duration / capacity;
+        let state = Atomic::new(BucketState {
+            level: Duration::new(0, 0),
+            last_update: None,
+        });
         Ok(LeakyBucket {
-            last: None,
-            current: Duration::new(0, 0),
+            state: Arc::new(state),
             token_interval: token_interval,
             full: per_duration,
         })
@@ -89,42 +109,55 @@ impl LeakyBucket {
         LeakyBucket::new(capacity, Duration::from_secs(1))
     }
 
-    /// Wraps the current leaky bucket in a
-    /// [`Threadsafe`](../struct.Threadsafe.html).
-    pub fn threadsafe(self) -> Threadsafe<LeakyBucket> {
-        Threadsafe::new(self)
+    /// Returns `self`, as this implementation is threadsafe
+    /// already. This method is deprecated and will be removed in a
+    /// future release.
+    pub fn threadsafe(self) -> LeakyBucket {
+        self
     }
 }
 
 impl MultiDeciderImpl for LeakyBucket {
     fn test_n_and_update(&mut self, n: u32, t0: Instant) -> Result<Decision<Duration>> {
-        if self.token_interval * n > self.full {
+        let weight = self.token_interval * n;
+        if weight > self.full {
             return Err(ErrorKind::InsufficientCapacity(n).into());
         }
+        let mut new = Owned::new(BucketState {
+            last_update: Some(t0),
+            level: Duration::new(0, 0),
+        });
+        let guard = epoch::pin();
 
-        let current = self.current;
-        let last = match self.last {
-            None => {
-                self.last = Some(t0);
-                t0
+        loop {
+            match self.state.load(Relaxed, &guard) {
+                Some(state) => {
+                    let last = state.last_update.unwrap_or(t0);
+                    // Prevent time travel: If any parallel calls get re-ordered,
+                    // or any tests attempt silly things, make sure to answer from
+                    // the last query onwards instead.
+                    let t0 = cmp::max(t0, last);
+                    // Decrement the level by however much needed:
+                    new.level = state.level - cmp::min(t0 - last, state.level);
+
+                    let mut decision = Decision::Yes;
+                    if weight + new.level <= self.full {
+                        new.level = new.level + weight;
+                    } else {
+                        let wait_period = (weight + new.level) - self.full;
+                        decision = Decision::No(wait_period);
+                    }
+                    match self.state.cas_and_ref(Some(state), new, Release, &guard) {
+                        Ok(_) => {
+                            return Ok(decision);
+                        }
+                        Err(owned) => {
+                            new = owned;
+                        }
+                    }
+                }
+                None => {} // retry.
             }
-            Some(t) => t,
-        };
-        // Prevent time travel: If any parallel calls get re-ordered,
-        // or any tests attempt silly things, make sure to answer from
-        // the last query onwards instead.
-        let t0 = cmp::max(t0, last);
-
-        self.current = current - cmp::min(t0 - last, current);
-        self.last = Some(t0);
-
-        let weight = self.token_interval * n;
-        if weight + self.current <= self.full {
-            self.current += weight;
-            Ok(Decision::Yes)
-        } else {
-            let wait_period = (weight + current) - self.full;
-            Ok(Decision::No(wait_period))
         }
     }
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -4,4 +4,5 @@ mod threadsafe;
 
 pub use self::gcra::GCRA;
 pub use self::leaky_bucket::LeakyBucket;
+#[allow(deprecated)]
 pub use self::threadsafe::*;

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -3,6 +3,7 @@ use {MultiDeciderImpl, DeciderImpl, TypedDecider, Decider, Decision, Result};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+#[deprecated = "all Deciders in this crate are threadsafe by default."]
 #[derive(Clone)]
 /// A wrapper that ensures operations in otherwise thread-unsafe
 /// rate-limiting decision algorithms are thread-safe.
@@ -10,6 +11,10 @@ use std::time::Instant;
 /// This is implemented by wrapping the actual Decider implementation
 /// in an atomically reference-counted mutex. It takes out a mutex
 /// whenever `.test_and_update()` is called.
+///
+/// ## Deprecation notice
+/// `Threadsafe` is deprecated, as all `Decider` implementations in
+/// this crate are threadsafe (and operate lock-free).
 pub struct Threadsafe<Impl>
 where
     Impl: Decider + Sized + Clone,
@@ -17,6 +22,7 @@ where
     sub: Arc<Mutex<Impl>>,
 }
 
+#[allow(deprecated)]
 impl<Impl> Threadsafe<Impl>
 where
     Impl: Decider + Sized + Clone,
@@ -28,6 +34,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<Impl> TypedDecider for Threadsafe<Impl>
 where
     Impl: TypedDecider + Decider + Sized + Clone,
@@ -35,6 +42,7 @@ where
     type T = Impl::T;
 }
 
+#[allow(deprecated)]
 impl<Impl> DeciderImpl for Threadsafe<Impl>
 where
     Impl: Decider + Sized + Clone,
@@ -44,6 +52,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<Impl> MultiDeciderImpl for Threadsafe<Impl>
 where
     Impl: MultiDeciderImpl + Decider + Sized + Clone,
@@ -53,6 +62,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<Impl> Decider for Threadsafe<Impl>
 where
     Impl: Decider + Sized + Clone,

--- a/src/algorithms/threadsafe.rs
+++ b/src/algorithms/threadsafe.rs
@@ -1,5 +1,4 @@
 use {MultiDeciderImpl, DeciderImpl, TypedDecider, Decider, Decision, Result};
-use algorithms::gcra::{GCRA, Builder};
 
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -58,28 +57,4 @@ impl<Impl> Decider for Threadsafe<Impl>
 where
     Impl: Decider + Sized + Clone,
 {
-}
-
-/// Allows converting from a GCRA builder directly into a threadsafe
-/// GCRA decider. For example:
-/// # Example
-/// ```
-/// use ratelimit_meter::{GCRA, Decider, Threadsafe, Decision};
-/// let mut gcra_sync: Threadsafe<GCRA> = GCRA::for_capacity(50).unwrap().into();
-/// assert_eq!(Decision::Yes, gcra_sync.check().unwrap());
-/// ```
-impl<'a> From<&'a Builder> for Threadsafe<GCRA> {
-    fn from(b: &'a Builder) -> Self {
-        b.build_sync()
-    }
-}
-
-/// Allows converting from a GCRA builder directly into a threadsafe
-/// GCRA decider. Same as
-/// [the borrowed implementation](#impl-From<&'a Builder>), except for
-/// owned `Builder`s.
-impl<'a> From<Builder> for Threadsafe<GCRA> {
-    fn from(b: Builder) -> Self {
-        b.build_sync()
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub mod errors;
 pub mod algorithms;
 mod implementation;
 
+extern crate crossbeam;
 #[macro_use]
 extern crate error_chain;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! let mut lim = GCRA::for_capacity(50).unwrap() // Allow 50 units of work
 //!     .per(Duration::from_secs(1)) // We calculate per-second (this is the default).
 //!     .cell_weight(1).unwrap() // Each cell is one unit of work "heavy".
-//!     .build(); // Construct a non-threadsafe GCRA decider.
+//!     .build(); // Construct a GCRA decider.
 //! assert_eq!(Decision::Yes, lim.check().unwrap());
 //! ```
 //!
@@ -87,24 +87,22 @@
 //!
 //! ## Thread-safe operation
 //!
-//! None of the stateful implementations in this crate can be used
-//! across threads by default. However, there is a wrapper struct
-//! [`Threadsafe`](algorithms/struct.Threadsafe.html), that wraps each
-//! implementation's hot path in an atomically reference-counted
-//! mutex. It still manages to be pretty fast (see the benchmarks
-//! above), but the lock comes with an overhead even in
-//! single-threaded operation.
+//! The implementations in this crate use compare-and-set to keep
+//! state, and are safe to share across threads..
 //!
 //! Example:
 //!
 //! ```
+//! use std::thread;
 //! use std::time::Duration;
 //! use ratelimit_meter::{Decider, GCRA, Decision};
 //!
 //! let mut lim = GCRA::for_capacity(50).unwrap() // Allow 50 units of work
 //!     .per(Duration::from_secs(1)) // We calculate per-second (this is the default).
 //!     .cell_weight(1).unwrap() // Each cell is one unit of work "heavy".
-//!     .build_sync(); // Construct a threadsafe GCRA decider.
+//!     .build(); // Construct a GCRA decider.
+//! let mut thread_lim = lim.clone();
+//! thread::spawn(move || { assert_eq!(Decision::Yes, thread_lim.check().unwrap()); });
 //! assert_eq!(Decision::Yes, lim.check().unwrap());
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 
 pub mod example_algorithms;
 pub mod errors;
+#[allow(deprecated)]
 pub mod algorithms;
 mod implementation;
 

--- a/tests/threadsafe.rs
+++ b/tests/threadsafe.rs
@@ -1,15 +1,18 @@
 extern crate ratelimit_meter;
 
+#[allow(deprecated)]
 use ratelimit_meter::{Threadsafe, GCRA, Decider, Decision};
 use std::thread;
 use std::time::{Instant, Duration};
 
+#[allow(deprecated)]
 #[test]
 fn simple_operation() {
     let mut lim = Threadsafe::new(GCRA::for_capacity(5).unwrap().build());
     assert_eq!(Decision::Yes, lim.check().unwrap());
 }
 
+#[allow(deprecated)]
 #[test]
 fn actual_threadsafety() {
     let mut lim = Threadsafe::new(GCRA::for_capacity(20).unwrap().build());


### PR DESCRIPTION
This PR is meant to refactor the buckety algorithms into lock-free ones, which (experimentally) speeds up the multi-threaded benchmarks by like 150x.

I've implemented these so far:

- [x] leaky bucket
- [x] GCRA
- [x] deprecate (in docs) `Threadsafe`
- [x] audit the `Ordering` argument - I only copied that from crossbeam's docs, have no idea what their actual effect is yet.

`Threadsafe` & the threadsafe-named methods will stick around, deprecated; to be removed in a future release.