### PR TITLE
Fix memory leaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ travis-ci = { repository = "antifuchs/ratelimit_meter", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-crossbeam = "0.3.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ crossbeam = "0.3.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 
+[dev_dependencies]
+libc = "0.2.41"
+
 [package.metadata.release]
 sign-commit = false
 upload-doc = false

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -4,8 +4,8 @@ extern crate ratelimit_meter;
 extern crate test;
 
 use ratelimit_meter::{Decider, LeakyBucket, GCRA};
-use std::time::{Duration, Instant};
 use std::thread;
+use std::time::{Duration, Instant};
 
 #[bench]
 fn bench_gcra_20threads(b: &mut test::Bencher) {

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -3,8 +3,8 @@
 extern crate ratelimit_meter;
 extern crate test;
 
-use ratelimit_meter::{Decider, LeakyBucket, MultiDecider, GCRA};
 use ratelimit_meter::example_algorithms::Allower;
+use ratelimit_meter::{Decider, LeakyBucket, MultiDecider, GCRA};
 use std::time::{Duration, Instant};
 
 #[bench]

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -111,7 +111,7 @@ impl Builder {
         if self.cell_weight > self.capacity {
             return Err(InconsistentCapacity {
                 capacity: self.capacity,
-                weight: weight,
+                weight,
             });
         }
         self.cell_weight = weight;
@@ -144,12 +144,12 @@ impl GCRA {
     pub fn for_capacity(capacity: u32) -> Result<Builder, InconsistentCapacity> {
         if capacity == 0 {
             return Err(InconsistentCapacity {
-                capacity: capacity,
+                capacity,
                 weight: 0,
             });
         }
         Ok(Builder {
-            capacity: capacity,
+            capacity,
             cell_weight: 1,
             time_unit: Duration::from_secs(1),
         })
@@ -162,8 +162,8 @@ impl GCRA {
     /// would accept another cell).
     pub fn with_parameters<T: Into<Option<Instant>>>(t: Duration, tau: Duration, tat: T) -> GCRA {
         GCRA {
-            t: t,
-            tau: tau,
+            t,
+            tau,
             tat: ThreadsafeWrapper::new(Tat(tat.into())),
         }
     }

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -198,7 +198,7 @@ impl MultiDeciderImpl for GCRA {
     fn test_n_and_update(&mut self, n: u32, t0: Instant) -> Result<(), NegativeMultiDecision> {
         let tau = self.tau;
         let t = self.t;
-        self.tat.measure_and_replace_n(|tat| {
+        self.tat.measure_and_replace(|tat| {
             let tat = tat.0.unwrap_or(t0);
             let tat = match n {
                 0 => t0,

--- a/src/algorithms/gcra.rs
+++ b/src/algorithms/gcra.rs
@@ -1,12 +1,9 @@
-use {Decider, DeciderImpl, MultiDecider, MultiDeciderImpl, NegativeMultiDecision, NonConformance};
 use algorithms::InconsistentCapacity;
+use thread_safety::ThreadsafeWrapper;
+use {Decider, DeciderImpl, MultiDecider, MultiDeciderImpl, NegativeMultiDecision, NonConformance};
 
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
-use std::time::{Duration, Instant};
 use std::cmp;
-use std::sync::Arc;
-
-use crossbeam::epoch::{self, Atomic, Owned};
+use std::time::{Duration, Instant};
 
 impl Decider for GCRA {}
 
@@ -19,6 +16,24 @@ impl Decider for GCRA {}
 /// users of this trait on GCRA limiters should ensure that this is
 /// ok.
 impl MultiDecider for GCRA {}
+
+#[derive(Debug, PartialEq, Clone)]
+struct Tat(Option<Instant>);
+
+impl Default for Tat {
+    fn default() -> Self {
+        Tat(None)
+    }
+}
+
+impl<T> From<T> for Tat
+where
+    T: Into<Option<Instant>>,
+{
+    fn from(f: T) -> Self {
+        Tat(f.into())
+    }
+}
 
 #[derive(Debug, Clone)]
 /// Implements the virtual scheduling description of the Generic Cell
@@ -77,7 +92,7 @@ pub struct GCRA {
     tau: Duration,
 
     // The theoretical arrival time of the next packet.
-    tat: Arc<Atomic<Instant>>,
+    tat: ThreadsafeWrapper<Tat>,
 }
 
 /// A builder object that can be used to construct rate-limiters as
@@ -117,7 +132,7 @@ impl Builder {
         GCRA {
             t: (self.time_unit / self.capacity) * self.cell_weight,
             tau: self.time_unit,
-            tat: Arc::new(Atomic::null()),
+            tat: ThreadsafeWrapper::<Tat>::default(),
         }
     }
 }
@@ -145,18 +160,11 @@ impl GCRA {
     /// tau (τ, the number of cells that fit into this buffer), and an
     /// optional t_at (the earliest instant that the rate-limiter
     /// would accept another cell).
-    pub fn with_parameters(t: Duration, tau: Duration, tat: Option<Instant>) -> GCRA {
-        match tat {
-            Some(ts) => GCRA {
-                t: t,
-                tau: tau,
-                tat: Arc::new(Atomic::new(ts)),
-            },
-            None => GCRA {
-                t: t,
-                tau: tau,
-                tat: Arc::new(Atomic::null()),
-            },
+    pub fn with_parameters<T: Into<Option<Instant>>>(t: Duration, tau: Duration, tat: T) -> GCRA {
+        GCRA {
+            t: t,
+            tau: tau,
+            tat: ThreadsafeWrapper::new(Tat(tat.into())),
         }
     }
 }
@@ -167,29 +175,16 @@ impl DeciderImpl for GCRA {
     /// of the method described directly in the GCRA algorithm, and is
     /// the fastest.
     fn test_and_update(&mut self, t0: Instant) -> Result<(), NonConformance> {
-        let guard = epoch::pin();
-        loop {
-            let tat_there = self.tat.load(Acquire, &guard);
-            let tat = match tat_there {
-                Some(sh) => **sh,
-                None => t0,
-            };
-
-            if t0 < tat - self.tau {
-                return Err(NonConformance::new(t0, tat - t0));
+        let tau = self.tau;
+        let t = self.t;
+        self.tat.measure_and_replace(|tat| {
+            let tat = tat.0.unwrap_or(t0);
+            if t0 < tat - tau {
+                (Err(NonConformance::new(t0, tat - t0)), None)
+            } else {
+                (Ok(()), Some(Tat(Some(cmp::max(tat, t0) + t))))
             }
-            if self.tat
-                .cas_and_ref(
-                    tat_there,
-                    Owned::new(cmp::max(tat, t0) + self.t),
-                    Release,
-                    &guard,
-                )
-                .is_ok()
-            {
-                return Ok(());
-            }
-        }
+        })
     }
 }
 
@@ -201,48 +196,43 @@ impl MultiDeciderImpl for GCRA {
     /// it is likely not as fast (and not as obviously "right") as the
     /// single-cell variant.
     fn test_n_and_update(&mut self, n: u32, t0: Instant) -> Result<(), NegativeMultiDecision> {
-        let guard = epoch::pin();
-        loop {
-            let tat_there = self.tat.load(Acquire, &guard);
-            let tat = match tat_there {
-                Some(sh) => **sh,
-                None => t0,
-            };
+        let tau = self.tau;
+        let t = self.t;
+        self.tat.measure_and_replace_n(|tat| {
+            let tat = tat.0.unwrap_or(t0);
             let tat = match n {
                 0 => t0,
                 1 => tat,
                 _ => {
-                    let weight = self.t * (n - 1);
-                    if (weight + self.t) > self.tau {
+                    let weight = t * (n - 1);
+                    if (weight + t) > tau {
                         // The bucket capacity can never accommodate this request
-                        return Err(NegativeMultiDecision::InsufficientCapacity(n));
+                        return (Err(NegativeMultiDecision::InsufficientCapacity(n)), None);
                     }
                     tat + weight
                 }
             };
-            if t0 < tat - self.tau {
-                return Err(NegativeMultiDecision::BatchNonConforming(
-                    n,
-                    NonConformance::new(t0, tat - t0),
-                ));
-            }
+
             let additional_weight = match n {
                 0 => Duration::new(0, 0),
-                1 => self.t,
-                _ => self.t * n,
+                1 => t,
+                _ => t * n,
             };
-            if self.tat
-                .cas_and_ref(
-                    tat_there,
-                    Owned::new(cmp::max(tat, t0) + additional_weight),
-                    Release,
-                    &guard,
+            if t0 < tat - tau {
+                (
+                    Err(NegativeMultiDecision::BatchNonConforming(
+                        n,
+                        NonConformance::new(t0, tat - t0),
+                    )),
+                    None,
                 )
-                .is_ok()
-            {
-                return Ok(());
+            } else {
+                (
+                    Ok(()),
+                    Some(Tat(Some(cmp::max(tat, t0) + additional_weight))),
+                )
             }
-        }
+        })
     }
 }
 
@@ -286,11 +276,7 @@ impl<'a> From<&'a mut Builder> for GCRA {
 /// construct a copy of the GCRA rate-limiter.
 impl<'a> Into<(Duration, Duration, Option<Instant>)> for &'a GCRA {
     fn into(self) -> (Duration, Duration, Option<Instant>) {
-        let guard = epoch::pin();
-        let tat = match self.tat.load(Relaxed, &guard) {
-            None => None,
-            Some(sh) => Some(**sh),
-        };
+        let tat = self.tat.snapshot().0;
         (self.t, self.tau, tat)
     }
 }

--- a/src/algorithms/leaky_bucket.rs
+++ b/src/algorithms/leaky_bucket.rs
@@ -85,14 +85,14 @@ impl LeakyBucket {
     pub fn new(capacity: u32, per_duration: Duration) -> Result<LeakyBucket, InconsistentCapacity> {
         if capacity == 0 {
             return Err(InconsistentCapacity {
-                capacity: capacity,
+                capacity,
                 weight: 0,
             });
         }
         let token_interval = per_duration / capacity;
         Ok(LeakyBucket {
             state: ThreadsafeWrapper::new(BucketState::default()),
-            token_interval: token_interval,
+            token_interval,
             full: per_duration,
         })
     }

--- a/src/algorithms/leaky_bucket.rs
+++ b/src/algorithms/leaky_bucket.rs
@@ -1,13 +1,10 @@
+use algorithms::InconsistentCapacity;
+use thread_safety::ThreadsafeWrapper;
 use {Decider, ImpliedDeciderImpl, MultiDecider, MultiDeciderImpl, NegativeMultiDecision,
      NonConformance};
-use algorithms::InconsistentCapacity;
 
-use std::sync::atomic::Ordering::{Acquire, Release};
-use std::time::{Duration, Instant};
 use std::cmp;
-use std::sync::Arc;
-
-use crossbeam::epoch::{self, Atomic, Owned};
+use std::time::{Duration, Instant};
 
 impl Decider for LeakyBucket {}
 
@@ -48,7 +45,7 @@ impl MultiDecider for LeakyBucket {}
 /// assert_eq!(Ok(()), lb.check());
 /// ```
 pub struct LeakyBucket {
-    state: Arc<Atomic<BucketState>>,
+    state: ThreadsafeWrapper<BucketState>,
     full: Duration,
     token_interval: Duration,
 }
@@ -57,6 +54,15 @@ pub struct LeakyBucket {
 struct BucketState {
     level: Duration,
     last_update: Option<Instant>,
+}
+
+impl Default for BucketState {
+    fn default() -> Self {
+        BucketState {
+            level: Duration::new(0, 0),
+            last_update: None,
+        }
+    }
 }
 
 impl LeakyBucket {
@@ -84,12 +90,8 @@ impl LeakyBucket {
             });
         }
         let token_interval = per_duration / capacity;
-        let state = Atomic::new(BucketState {
-            level: Duration::new(0, 0),
-            last_update: None,
-        });
         Ok(LeakyBucket {
-            state: Arc::new(state),
+            state: ThreadsafeWrapper::new(BucketState::default()),
             token_interval: token_interval,
             full: per_duration,
         })
@@ -104,47 +106,38 @@ impl LeakyBucket {
 
 impl MultiDeciderImpl for LeakyBucket {
     fn test_n_and_update(&mut self, n: u32, t0: Instant) -> Result<(), NegativeMultiDecision> {
+        let full = self.full;
         let weight = self.token_interval * n;
         if weight > self.full {
             return Err(NegativeMultiDecision::InsufficientCapacity(n));
         }
-        let mut new = Owned::new(BucketState {
-            last_update: Some(t0),
-            level: Duration::new(0, 0),
-        });
-        let guard = epoch::pin();
-
-        loop {
-            if let Some(state) = self.state.load(Acquire, &guard) {
-                let last = state.last_update.unwrap_or(t0);
-                // Prevent time travel: If any parallel calls get re-ordered,
-                // or any tests attempt silly things, make sure to answer from
-                // the last query onwards instead.
-                let t0 = cmp::max(t0, last);
-                // Decrement the level by the amount the bucket
-                // has dripped in the meantime:
-                new.level = state.level - cmp::min(t0 - last, state.level);
-
-                // Determine if the cell fits & ensure it is recorded:
-                if weight + new.level <= self.full {
-                    new.level += weight;
-                    match self.state.cas_and_ref(Some(state), new, Release, &guard) {
-                        Ok(_) => {
-                            return Ok(());
-                        }
-                        Err(owned) => {
-                            new = owned;
-                        }
-                    }
-                } else {
-                    let wait_period = (weight + new.level) - self.full;
-                    return Err(NegativeMultiDecision::BatchNonConforming(
+        self.state.measure_and_replace_n(|state| {
+            let mut new = BucketState {
+                last_update: Some(t0),
+                level: Duration::new(0, 0),
+            };
+            let last = state.last_update.unwrap_or(t0);
+            // Prevent time travel: If any parallel calls get re-ordered,
+            // or any tests attempt silly things, make sure to answer from
+            // the last query onwards instead.
+            let t0 = cmp::max(t0, last);
+            // Decrement the level by the amount the bucket
+            // has dripped in the meantime:
+            new.level = state.level - cmp::min(t0 - last, state.level);
+            if weight + new.level <= full {
+                new.level += weight;
+                (Ok(()), Some(new))
+            } else {
+                let wait_period = (weight + new.level) - full;
+                (
+                    Err(NegativeMultiDecision::BatchNonConforming(
                         n,
                         NonConformance::new(t0, wait_period),
-                    ));
-                }
+                    )),
+                    None,
+                )
             }
-        }
+        })
     }
 }
 

--- a/src/algorithms/leaky_bucket.rs
+++ b/src/algorithms/leaky_bucket.rs
@@ -111,7 +111,7 @@ impl MultiDeciderImpl for LeakyBucket {
         if weight > self.full {
             return Err(NegativeMultiDecision::InsufficientCapacity(n));
         }
-        self.state.measure_and_replace_n(|state| {
+        self.state.measure_and_replace(|state| {
             let mut new = BucketState {
                 last_update: Some(t0),
                 level: Duration::new(0, 0),

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -1,5 +1,5 @@
-use {NegativeMultiDecision, NonConformance};
 use std::time::Instant;
+use {NegativeMultiDecision, NonConformance};
 
 /// The trait that implementations of the metered rate-limiter
 /// interface have to implement. Users of this library should rely on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,11 @@
 //! assert_eq!(Ok(()), lim.check());
 //! ```
 
-pub mod example_algorithms;
 pub mod algorithms;
+pub mod example_algorithms;
 mod implementation;
+mod thread_safety;
 
-extern crate crossbeam;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@ use std::time::{Duration, Instant};
 
 use implementation::*;
 
-pub use self::algorithms::GCRA;
 pub use self::algorithms::LeakyBucket;
+pub use self::algorithms::GCRA;
 
 /// Provides additional information about non-conforming cells, most
 /// importantly the earliest time until the next cell could be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,7 @@ pub struct NonConformance {
 
 impl NonConformance {
     pub(crate) fn new(t0: Instant, min_time: Duration) -> NonConformance {
-        NonConformance {
-            t0: t0,
-            min_time: min_time,
-        }
+        NonConformance { t0, min_time }
     }
 }
 

--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -1,0 +1,103 @@
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use {NegativeMultiDecision, NonConformance};
+
+#[derive(Clone)]
+pub(crate) struct ThreadsafeWrapper<T>
+where
+    T: fmt::Debug + Default + Clone,
+{
+    data: Arc<Mutex<T>>,
+}
+
+impl<T> Default for ThreadsafeWrapper<T>
+where
+    T: fmt::Debug + Default + Clone,
+{
+    fn default() -> Self {
+        ThreadsafeWrapper {
+            data: Arc::new(Mutex::new(T::default())),
+        }
+    }
+}
+
+impl<T> fmt::Debug for ThreadsafeWrapper<T>
+where
+    T: fmt::Debug + Default + Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let data = self.data.lock();
+        data.fmt(f)
+    }
+}
+
+impl<T> ThreadsafeWrapper<T>
+where
+    T: fmt::Debug + Default + Clone,
+{
+    pub(crate) fn new(elt: T) -> ThreadsafeWrapper<T> {
+        ThreadsafeWrapper {
+            data: Arc::new(Mutex::new(elt)),
+        }
+    }
+
+    #[inline]
+    /// Wraps retrieving a bucket's data, calls a function to make a
+    /// decision and return a new state, and then tries to set the
+    /// state on the bucket.
+    ///
+    /// This function can loop and call the decision closure again if
+    /// the bucket state couldn't be set.
+    ///
+    /// # Panics
+    /// Panics if an error occurs in acquiring any locks.
+    pub(crate) fn measure_and_replace<F>(&mut self, f: F) -> Result<(), NonConformance>
+    where
+        F: Fn(&T) -> (Result<(), NonConformance>, Option<T>),
+    {
+        let mut data = self.data.lock().unwrap();
+        let (decision, new_data) = f(&*data);
+        if let Some(new_data) = new_data {
+            *data = new_data;
+        }
+        decision
+    }
+
+    #[inline]
+    /// Wraps retrieving a bucket's data, calls a function to make a
+    /// decision on n elements and return a new state, and then tries
+    /// to set the state on the bucket.
+    ///
+    /// This function can loop and call the decision closure again if
+    /// the bucket state couldn't be set.
+    ///
+    /// # Panics
+    /// Panics if an error occurs in acquiring any locks.
+    pub(crate) fn measure_and_replace_n<F>(&mut self, f: F) -> Result<(), NegativeMultiDecision>
+    where
+        F: Fn(&T) -> (Result<(), NegativeMultiDecision>, Option<T>),
+    {
+        let mut data = self.data.lock().unwrap();
+        let (decision, new_data) = f(&*data);
+        if let Some(new_data) = new_data {
+            *data = new_data;
+        }
+        decision
+    }
+
+    /// Retrieves and returns a snapshot of the bucket state. This
+    /// isn't thread safe, but can be used to restore an old copy of
+    /// the bucket if necessary.
+    ///
+    /// # Thread safety
+    /// This function operates threadsafely, but you're literally
+    /// taking a copy of data that will change. Relying on the data
+    /// that is returned is *not* threadsafe.
+    ///
+    /// # Panics
+    /// Panics if an error occurs in acquiring any locks.
+    pub(crate) fn snapshot(&self) -> T {
+        let data = self.data.lock().unwrap();
+        data.clone()
+    }
+}

--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -2,6 +2,8 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
+/// Wraps the atomic operations on a Decider's state in a threadsafe
+/// fashion.
 pub(crate) struct ThreadsafeWrapper<T>
 where
     T: fmt::Debug + Default + Clone,

--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::sync::{Arc, Mutex};
-use {NegativeMultiDecision, NonConformance};
 
 #[derive(Clone)]
 pub(crate) struct ThreadsafeWrapper<T>
@@ -51,31 +50,9 @@ where
     ///
     /// # Panics
     /// Panics if an error occurs in acquiring any locks.
-    pub(crate) fn measure_and_replace<F>(&mut self, f: F) -> Result<(), NonConformance>
+    pub(crate) fn measure_and_replace<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: Fn(&T) -> (Result<(), NonConformance>, Option<T>),
-    {
-        let mut data = self.data.lock().unwrap();
-        let (decision, new_data) = f(&*data);
-        if let Some(new_data) = new_data {
-            *data = new_data;
-        }
-        decision
-    }
-
-    #[inline]
-    /// Wraps retrieving a bucket's data, calls a function to make a
-    /// decision on n elements and return a new state, and then tries
-    /// to set the state on the bucket.
-    ///
-    /// This function can loop and call the decision closure again if
-    /// the bucket state couldn't be set.
-    ///
-    /// # Panics
-    /// Panics if an error occurs in acquiring any locks.
-    pub(crate) fn measure_and_replace_n<F>(&mut self, f: F) -> Result<(), NegativeMultiDecision>
-    where
-        F: Fn(&T) -> (Result<(), NegativeMultiDecision>, Option<T>),
+        F: Fn(&T) -> (Result<(), E>, Option<T>),
     {
         let mut data = self.data.lock().unwrap();
         let (decision, new_data) = f(&*data);

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -5,7 +5,6 @@ extern crate ratelimit_meter;
 use ratelimit_meter::{Decider, GCRA};
 use ratelimit_meter::{LeakyBucket, MultiDecider};
 use std::thread;
-use std::time::{Duration, Instant};
 
 fn resident_memsize() -> i64 {
     let mut out: libc::rusage = unsafe { std::mem::zeroed() };
@@ -13,7 +12,7 @@ fn resident_memsize() -> i64 {
     out.ru_maxrss
 }
 
-const LEAK_TOLERANCE: i64 = 1024 * 100;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 10;
 
 fn check_for_leaks(n_iter: usize, usage_before: i64) {
     let usage_after = resident_memsize();

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,0 +1,89 @@
+// This test uses procinfo, so can only be run on Linux.
+extern crate libc;
+extern crate ratelimit_meter;
+
+use ratelimit_meter::{Decider, GCRA};
+use ratelimit_meter::{LeakyBucket, MultiDecider};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn resident_memsize() -> i64 {
+    let mut out: libc::rusage = unsafe { std::mem::zeroed() };
+    assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut out) } == 0);
+    out.ru_maxrss
+}
+
+const LEAK_TOLERANCE: i64 = 1024 * 100;
+
+fn check_for_leaks(n_iter: usize, usage_before: i64) {
+    let usage_after = resident_memsize();
+    assert!(
+        usage_after <= usage_before + LEAK_TOLERANCE,
+        "Plausible memory leak!\nAfter {} iterations, usage before: {}, usage after: {}",
+        n_iter,
+        usage_before,
+        usage_after
+    );
+}
+
+#[test]
+fn memleak_gcra() {
+    const N_ITER: usize = 500_000;
+    let mut bucket = GCRA::for_capacity(1_000_000).unwrap().build();
+    let usage_before = resident_memsize();
+
+    for _i in 0..N_ITER {
+        drop(bucket.check());
+    }
+    check_for_leaks(N_ITER, usage_before);
+}
+
+#[test]
+fn memleak_gcra_multi() {
+    const N_ITER: usize = 500_000;
+    let mut bucket = GCRA::for_capacity(1_000_000).unwrap().build();
+    let usage_before = resident_memsize();
+
+    for _i in 0..N_ITER {
+        drop(bucket.check_n(2));
+    }
+    check_for_leaks(N_ITER, usage_before);
+}
+
+#[test]
+fn memleak_gcra_threaded() {
+    const N_ITER: usize = 5_000;
+    let bucket = GCRA::for_capacity(1_000_000).unwrap().build();
+    let usage_before = resident_memsize();
+
+    for _i in 0..N_ITER {
+        let mut bucket = bucket.clone();
+        thread::spawn(move || drop(bucket.check())).join().unwrap();
+    }
+    check_for_leaks(N_ITER, usage_before);
+}
+
+#[test]
+fn memleak_leakybucket() {
+    const N_ITER: usize = 500_000;
+    let mut bucket = LeakyBucket::per_second(1_000_000).unwrap();
+    let usage_before = resident_memsize();
+
+    for _i in 0..N_ITER {
+        drop(bucket.check());
+    }
+    check_for_leaks(N_ITER, usage_before);
+}
+
+#[test]
+fn memleak_leakybucket_threaded() {
+    const N_ITER: usize = 5_000;
+    let bucket = LeakyBucket::per_second(1_000_000).unwrap();
+    let usage_before = resident_memsize();
+
+    for _i in 0..N_ITER {
+        let mut bucket = bucket.clone();
+        thread::spawn(move || drop(bucket.check())).join().unwrap();
+    }
+    check_for_leaks(N_ITER, usage_before);
+}


### PR DESCRIPTION
This PR tracks the work on plugging the memory leak in both decision algorithms, discovered in #17. The current strategy is to rewrite the whole thing using mutexes (with a crate-internal wrapper).

I've also made a test (using `getrusage`) to check if a lot of calls leak more memory than they should. The bounds are correct on my laptop, I hope they'll be ok on Travis too.

This change improves single-threaded performance and makes multi-threaded performance a bit worse (which was tainted by the memory issue though, so who's to say).

Benchmarks before:
```
     Running target/release/deps/multi_threaded-d8bd7867e9908eda

running 2 tests
test bench_gcra_20threads         ... bench:         138 ns/iter (+/- 2,129)
test bench_leaky_bucket_20threads ... bench:         567 ns/iter (+/- 11,141)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/single_threaded-b5dced51ae82c67e

running 6 tests
test bench_allower                 ... bench:          22 ns/iter (+/- 11)
test bench_gcra                    ... bench:         145 ns/iter (+/- 64)
test bench_gcra_bulk               ... bench:         249 ns/iter (+/- 539)
test bench_leaky_bucket            ... bench:         164 ns/iter (+/- 47)
test bench_leaky_bucket_bulk       ... bench:         178 ns/iter (+/- 100)
test bench_threadsafe_leaky_bucket ... bench:         200 ns/iter (+/- 134)
```

Benchmarks after:
```
     Running target/release/deps/multi_threaded-bab1ac060974eb03

running 2 tests
test bench_gcra_20threads         ... bench:      29,887 ns/iter (+/- 42,982)
test bench_leaky_bucket_20threads ... bench:     108,383 ns/iter (+/- 33,229)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/single_threaded-c89da25a5fa0b4d2

running 6 tests
test bench_allower                 ... bench:          20 ns/iter (+/- 2)
test bench_gcra                    ... bench:          80 ns/iter (+/- 23)
test bench_gcra_bulk               ... bench:         102 ns/iter (+/- 13)
test bench_leaky_bucket            ... bench:          75 ns/iter (+/- 8)
test bench_leaky_bucket_bulk       ... bench:          77 ns/iter (+/- 24)
test bench_threadsafe_leaky_bucket ... bench:          76 ns/iter (+/- 16)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out
```