### PR TITLE
Default NonConformance's type argument

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -23,7 +23,7 @@ pub type DefaultAlgorithm = LeakyBucket;
 ///
 /// Since this does not account for effects like thundering herds,
 /// users should always add random jitter to the times given.
-pub trait NonConformance<P: instant::Relative> {
+pub trait NonConformance<P: instant::Relative = instant::TimeSource> {
     /// Returns the earliest time at which a decision could be
     /// conforming (excluding conforming decisions made by the Decider
     /// that are made in the meantime).


### PR DESCRIPTION
This should fix #27, where @jbg notes correctly that ratelimit_futures no longer builds (because it pulls in the 4.1 release now). This change makes it build again.