### PR TITLE
Enable no_std builds on stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"no_std": CustomEntry(MatrixEntry { run: true, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
+# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"no_std_nightly": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" }), "no_std_stable": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo +stable test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
 version: "2.1"
 
 executors:
@@ -78,7 +78,7 @@ jobs:
       - run:
           name: Bench
           command: cargo bench
-  no_std:
+  no_std_nightly:
     parameters:
       version:
         type: executor
@@ -92,6 +92,20 @@ jobs:
       - run:
           name: cargo +nightly test --no-default-features --features no_std
           command: cargo +nightly test --no-default-features --features no_std
+  no_std_stable:
+    parameters:
+      version:
+        type: executor
+      version_name:
+        type: string
+    executor: << parameters.version >>
+    environment:
+      CI_RUST_VERSION: << parameters.version_name >>
+    steps:
+      - checkout
+      - run:
+          name: cargo +stable test --no-default-features --features no_std
+          command: cargo +stable test --no-default-features --features no_std
 
   ci_success:
     docker:
@@ -178,10 +192,14 @@ workflows:
     ]
   }
 }
-      - no_std:
-          name: "no_std"
+      - no_std_nightly:
+          name: "no_std_nightly"
           version: nightly
           version_name: nightly
+      - no_std_stable:
+          name: "no_std_stable"
+          version: stable
+          version_name: stable
       - ci_success:
           requires:
           - test-stable
@@ -189,7 +207,8 @@ workflows:
           - rustfmt
           - clippy
           - bench
-          - no_std
+          - no_std_nightly
+          - no_std_stable
   scheduled_tests:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"no_std_nightly": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" }), "no_std_stable": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo +stable test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
+# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"no_std_stable": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo test --no-default-features --features no_std" }), "no_std_nightly": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
 version: "2.1"
 
 executors:
@@ -78,6 +78,20 @@ jobs:
       - run:
           name: Bench
           command: cargo bench
+  no_std_stable:
+    parameters:
+      version:
+        type: executor
+      version_name:
+        type: string
+    executor: << parameters.version >>
+    environment:
+      CI_RUST_VERSION: << parameters.version_name >>
+    steps:
+      - checkout
+      - run:
+          name: cargo test --no-default-features --features no_std
+          command: cargo test --no-default-features --features no_std
   no_std_nightly:
     parameters:
       version:
@@ -92,20 +106,6 @@ jobs:
       - run:
           name: cargo +nightly test --no-default-features --features no_std
           command: cargo +nightly test --no-default-features --features no_std
-  no_std_stable:
-    parameters:
-      version:
-        type: executor
-      version_name:
-        type: string
-    executor: << parameters.version >>
-    environment:
-      CI_RUST_VERSION: << parameters.version_name >>
-    steps:
-      - checkout
-      - run:
-          name: cargo +stable test --no-default-features --features no_std
-          command: cargo +stable test --no-default-features --features no_std
 
   ci_success:
     docker:
@@ -192,14 +192,14 @@ workflows:
     ]
   }
 }
-      - no_std_nightly:
-          name: "no_std_nightly"
-          version: nightly
-          version_name: nightly
       - no_std_stable:
           name: "no_std_stable"
           version: stable
           version_name: stable
+      - no_std_nightly:
+          name: "no_std_nightly"
+          version: nightly
+          version_name: nightly
       - ci_success:
           requires:
           - test-stable
@@ -207,8 +207,8 @@ workflows:
           - rustfmt
           - clippy
           - bench
-          - no_std_nightly
           - no_std_stable
+          - no_std_nightly
   scheduled_tests:
     jobs:
       - test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,15 @@ version = "stable"
 
 [package.metadata.template_ci.additional_matrix_entries]
 
-[package.metadata.template_ci.additional_matrix_entries.no_std]
+[package.metadata.template_ci.additional_matrix_entries.no_std_nightly]
 run = true
 version = "nightly"
 commandline = "cargo +nightly test --no-default-features --features no_std"
+
+[package.metadata.template_ci.additional_matrix_entries.no_std_stable]
+run = true
+version = "stable"
+commandline = "cargo +stable test --no-default-features --features no_std"
 
 [[bench]]
 name = "criterion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ commandline = "cargo +nightly test --no-default-features --features no_std"
 [package.metadata.template_ci.additional_matrix_entries.no_std_stable]
 run = true
 version = "stable"
-commandline = "cargo +stable test --no-default-features --features no_std"
+commandline = "cargo test --no-default-features --features no_std"
 
 [[bench]]
 name = "criterion"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,8 +212,6 @@
 //! lim.check().ok();
 //! ```
 
-// Allow using the alloc crate
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 // Allow using ratelimit_meter without std
 #![cfg_attr(not(feature = "std"), no_std)]
 // Deny warnings


### PR DESCRIPTION
Since 1.36, we can enable no_std on stable - let's do that.