### PR TITLE
Implement jitter for negative rate-limiting results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "ratelimit_meter"
-version = "5.0.1-dev"
+version = "5.1.0-dev"
 authors = ["Andreas Fuchs <asf@boinkor.net>"]
 license = "MIT"
 homepage = "https://github.com/antifuchs/ratelimit_meter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ nonzero_ext = {version = "0.1.5", default-features = false}
 spin = {version = "0.5.0", optional = true}
 parking_lot = {version = "0.9.0", optional = true}
 evmap = {version = "6.0.0", optional = true}
+rand = "0.7.2"
 
 [dev_dependencies]
 libc = "0.2.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ spin = {version = "0.5.0", optional = true}
 parking_lot = {version = "0.9.0", optional = true}
 evmap = {version = "6.0.0", optional = true}
 rand = "0.7.2"
+once_cell = "1.2.0"
 
 [dev_dependencies]
 libc = "0.2.41"

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -25,7 +25,10 @@ pub type DefaultAlgorithm = LeakyBucket;
 ///
 /// Since this does not account for effects like thundering herds,
 /// users should always add random jitter to the times given.
-pub trait NonConformance<P: clock::Reference = <clock::DefaultClock as clock::Clock>::Instant> {
+pub trait NonConformance<P: clock::Reference = <clock::DefaultClock as clock::Clock>::Instant>
+where
+    Self: Sized + PartialEq + fmt::Debug + fmt::Display + Send + Sync,
+{
     /// Returns the earliest time at which a decision could be
     /// conforming (excluding conforming decisions made by the Decider
     /// that are made in the meantime).
@@ -63,11 +66,10 @@ pub trait Algorithm<P: clock::Reference = <clock::DefaultClock as clock::Clock>:
 
     /// The type returned when a rate limiting decision for a single
     /// cell is negative. Each rate limiting algorithm can decide to
-    /// return the type that suits it best, but most algorithms'
-    /// decisions also implement
+    /// return the type that suits it best, it must also implement
     /// [`NonConformance`](trait.NonConformance.html), to ease
     /// handling of how long to wait.
-    type NegativeDecision: PartialEq + fmt::Display + fmt::Debug + Send + Sync;
+    type NegativeDecision: NonConformance<P>;
 
     /// Constructs a rate limiter with the given parameters:
     /// `capacity` is the number of cells to allow, weighing

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -27,7 +27,7 @@ pub type DefaultAlgorithm = LeakyBucket;
 /// users should always add random jitter to the times given.
 pub trait NonConformance<P: clock::Reference = <clock::DefaultClock as clock::Clock>::Instant>
 where
-    Self: Sized + PartialEq + fmt::Debug + fmt::Display + Send + Sync,
+    Self: Sized + PartialEq + fmt::Debug + fmt::Display,
 {
     /// Returns the earliest time at which a decision could be
     /// conforming (excluding conforming decisions made by the Decider

--- a/src/example_algorithms.rs
+++ b/src/example_algorithms.rs
@@ -3,7 +3,7 @@
 use crate::lib::*;
 use crate::{
     algorithms::{Algorithm, RateLimitState},
-    clock, DirectRateLimiter, InconsistentCapacity, NegativeMultiDecision,
+    clock, DirectRateLimiter, InconsistentCapacity, NegativeMultiDecision, NonConformance,
 };
 
 /// The most naive implementation of a rate-limiter ever: Always
@@ -37,6 +37,13 @@ impl RateLimitState<Allower, Always> for () {
 /// positive result, so this error is never returned.
 #[derive(Debug, PartialEq)]
 pub enum Impossible {}
+
+// This is never used in practice, but the compiler demands it.
+impl NonConformance<Always> for Impossible {
+    fn earliest_possible(&self) -> Always {
+        Always()
+    }
+}
 
 impl fmt::Display for Impossible {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -6,8 +6,6 @@
 
 use crate::lib::*;
 use crate::{clock, NegativeMultiDecision, NonConformance};
-use once_cell::sync::OnceCell;
-use std::default::Default;
 
 /// A time interval specification that gets added to the wait time returned by the rate limiter's
 /// non-conformance results.

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -1,0 +1,121 @@
+//! Random additional wait time.
+//!
+//! With Jitter, rate limiters will return a time estimate that is artificially inflated
+//! by a random duration (capped at a maximum, with an optional minimum). This helps avoid
+//! thundering herds when many concurrent rate limit requests are being made.
+
+use crate::lib::*;
+use crate::{clock, NegativeMultiDecision, NonConformance};
+
+/// A time interval specification that gets added to the wait time returned by the rate limiter's
+/// non-conformance results.
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct Jitter {
+    min: Duration,
+    interval: Duration,
+}
+
+impl Jitter {
+    /// Constructs a new Jitter interval, waiting at most a duration of `max`.
+    pub fn up_to(max: Duration) -> Jitter {
+        Jitter {
+            min: Duration::new(0, 0),
+            interval: max,
+        }
+    }
+
+    /// Constructs a new Jitter interval, waiting at least `min` and at most `min+interval`.
+    pub fn new(min: Duration, interval: Duration) -> Jitter {
+        Jitter { min, interval }
+    }
+
+    /// Returns a random amount of jitter within the configured interval.
+    pub(crate) fn get(&self) -> Duration {
+        let range = rand::random::<f32>();
+        self.min + self.interval.mul_f32(range)
+    }
+}
+
+#[derive(PartialEq, Debug)]
+/// A non-conforming result that has had random jitter applied.
+pub struct NonConformanceWithJitter<NC: NonConformance<P>, P: clock::Reference> {
+    inner: NC,
+    additional: Duration,
+    phantom: PhantomData<P>,
+}
+
+impl<NC: NonConformance<P>, P: clock::Reference> NonConformanceWithJitter<NC, P> {
+    pub(crate) fn new(inner: NC, additional: Duration) -> NonConformanceWithJitter<NC, P> {
+        NonConformanceWithJitter {
+            inner,
+            additional,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<NC: NonConformance<P>, P: clock::Reference> NonConformance<P>
+    for NonConformanceWithJitter<NC, P>
+{
+    fn earliest_possible(&self) -> P {
+        self.inner.earliest_possible() + self.additional
+    }
+
+    fn wait_time_from(&self, from: P) -> Duration {
+        self.inner.wait_time_from(from) + self.additional
+    }
+}
+
+impl<NC: NonConformance<P>, P: clock::Reference> fmt::Display for NonConformanceWithJitter<NC, P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "rate-limited until {:?}", self.earliest_possible())
+    }
+}
+
+/// Apply random jitter to a negative single-cell decision.
+///
+/// See [`Jitter`].
+pub trait JitterResultExt<P: clock::Reference, NC: NonConformance<P>> {
+    /// Adjusts a potential negative decision so that it includes random jitter.
+    fn jitter(self, jitter: &Jitter) -> Result<(), NonConformanceWithJitter<NC, P>>;
+}
+
+/// Blanket implementation for applying jitter to any single-cell negative decision.
+impl<P: clock::Reference, NC: NonConformance<P>> JitterResultExt<P, NC> for Result<(), NC> {
+    fn jitter(self, jitter: &Jitter) -> Result<(), NonConformanceWithJitter<NC, P>> {
+        self.map_err(|nc| NonConformanceWithJitter::new(nc, jitter.get()))
+    }
+}
+
+/// Apply random jitter to a negative multi-cell decision.
+///
+/// See [`Jitter`].
+pub trait JitterMultiResultExt<P: clock::Reference, NC: NonConformance<P>> {
+    /// Adjusts a potential negative decision so that it includes random jitter.
+    fn jitter(
+        self,
+        jitter: &Jitter,
+    ) -> Result<(), NegativeMultiDecision<NonConformanceWithJitter<NC, P>>>;
+}
+
+/// Blanket implementation for applying jitter to any multi-cell negative decision.
+impl<P: clock::Reference, NC: NonConformance<P>> JitterMultiResultExt<P, NC>
+    for Result<(), NegativeMultiDecision<NC>>
+{
+    fn jitter(
+        self,
+        jitter: &Jitter,
+    ) -> Result<(), NegativeMultiDecision<NonConformanceWithJitter<NC, P>>> {
+        self.map_err(|decision| match decision {
+            NegativeMultiDecision::BatchNonConforming(n, nc) => {
+                NegativeMultiDecision::BatchNonConforming(
+                    n,
+                    NonConformanceWithJitter::new(nc, jitter.get()),
+                )
+            }
+            NegativeMultiDecision::InsufficientCapacity(n) => {
+                NegativeMultiDecision::InsufficientCapacity(n)
+            }
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,8 @@ pub mod state;
 pub mod test_utilities;
 mod thread_safety;
 
+pub mod prelude;
+
 #[macro_use]
 extern crate nonzero_ext;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@ pub mod algorithms;
 pub mod clock;
 mod errors;
 pub mod example_algorithms;
+pub mod jitter;
 pub mod state;
 pub mod test_utilities;
 mod thread_safety;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ mod lib {
     /// Imports that are only available on std.
     #[cfg(feature = "std")]
     mod std {
+        pub use once_cell::unsync::OnceCell;
         pub use std::collections::hash_map::RandomState;
         pub use std::hash::{BuildHasher, Hash};
         pub use std::sync::Arc;
@@ -280,6 +281,7 @@ mod lib {
     #[cfg(feature = "no_std")]
     mod no_std {
         pub use alloc::sync::Arc;
+        pub use once_cell::unsync::OnceCell;
     }
 
     #[cfg(feature = "std")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-//! A module exporting useful traits defined in this crate.  
+//! A module exporting useful traits defined in this crate.
 
 pub use crate::algorithms::NonConformance;
 pub use crate::jitter::JitterMultiResultExt;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,5 @@
+//! A module exporting useful traits defined in this crate.  
+
+pub use crate::algorithms::NonConformance;
+pub use crate::jitter::JitterMultiResultExt;
+pub use crate::jitter::JitterResultExt;

--- a/tests/leaky_bucket.rs
+++ b/tests/leaky_bucket.rs
@@ -127,7 +127,6 @@ fn tooearly_wait_time_from() {
 fn applies_jitter() {
     let mut lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(20u32));
     let now = current_moment();
-    let ms = Duration::from_millis(1);
 
     let j = Jitter::up_to(Duration::from_secs(1));
     lim.check_at(now).jitter(&j).unwrap();

--- a/tests/leaky_bucket.rs
+++ b/tests/leaky_bucket.rs
@@ -2,9 +2,10 @@ extern crate ratelimit_meter;
 #[macro_use]
 extern crate nonzero_ext;
 
+use ratelimit_meter::jitter::Jitter;
 use ratelimit_meter::{
-    algorithms::Algorithm, test_utilities::current_moment, DirectRateLimiter, LeakyBucket,
-    NegativeMultiDecision, NonConformance,
+    algorithms::Algorithm, prelude::*, test_utilities::current_moment, DirectRateLimiter,
+    LeakyBucket, NegativeMultiDecision, NonConformance,
 };
 use std::thread;
 use std::time::Duration;
@@ -120,4 +121,15 @@ fn tooearly_wait_time_from() {
     } else {
         assert!(false, "Second attempt should fail");
     }
+}
+
+#[test]
+fn applies_jitter() {
+    let mut lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(20u32));
+    let now = current_moment();
+    let ms = Duration::from_millis(1);
+
+    let j = Jitter::up_to(Duration::from_secs(1));
+    lim.check_at(now).jitter(&j).unwrap();
+    lim.check_n_at(1, now).jitter(&j).unwrap();
 }


### PR DESCRIPTION
This PR adds a Jitter data structure and uses the rand crate to generate additional wait time on negative results.

It also adds a prelude module, as there now exist several traits that users maybe should import.

TODO:
- [x] figure out if we can apply the jitter as a Direct/Keyed rate-limiter option, not manually on Results
- [x] see how performance changes when jitter is applied - I fear that adding a rand call on every negative result is not going to be fun