### PR TITLE
ThreadsafeWrapper: fix deadlock caused by comparing with itself

### DIFF
--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -32,6 +32,9 @@ where
     T: fmt::Debug + Default + Clone + PartialEq + Eq,
 {
     fn eq(&self, other: &Self) -> bool {
+        if self as *const _ == other as *const _ {
+            return true;
+        }
         let mine = self.data.lock();
         let other = other.data.lock();
         *other == *mine


### PR DESCRIPTION
In `ThreadsafeWrapper::eq(&self, other: &Self )`:
if `self` points to the same object with `other`, a deadlock may happen at L35 and L36:
https://github.com/antifuchs/ratelimit_meter/blob/2e3959513f9dba705f08b6e497749b10517c36e2/src/thread_safety.rs#L34-L37

The fix is to compare their addresses first.
`std::ptr::eq()` seems a neater choice but the implementation seems the same as the `as` converting here. Besides, I do not want to introduce `std` into this crate.